### PR TITLE
Fix #7 registry dedup and #8 helper over-tagging (v0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to sphinxcontrib-nexus.
 
+## 0.8.1 — 2026-04-13
+
+Two bug fixes caught by ORPHEUS cross-validation of 0.8.0.
+
+### Fixed
+
+- **nexus#7**: explicit-source edge dedup. Every write-time pass
+  (``merge.write_verifies_edges``, ``directives.apply_pending_edges``,
+  ``registry._apply_verifications`` / ``_apply_implementations``)
+  previously only skipped duplication against its **own** source.
+  A ``(test, equation)`` pair declared by both a
+  ``@pytest.mark.verifies`` decorator AND a matching registry
+  entry therefore produced two parallel ``tests`` edges, inflating
+  per-equation test counts by one (the exact 86 → 87 regression
+  reported from the ORPHEUS ``matrix-eigenvalue`` equation).
+
+  All four passes now skip if ANY edge of the same type has a
+  non-inference source already present. ``source="inferred"``
+  edges remain weak and can still coexist with explicit assertions.
+
+- **Query-time dedup layer** in ``verification_coverage`` tracks
+  seen ``(src, tgt)`` pairs per edge-type so each ``(code,
+  equation)`` or ``(test, equation)`` relationship contributes at
+  most one entry to the result. This is defense-in-depth for
+  graphs loaded from older nexus versions that may still carry
+  duplicate edges.
+
+- **nexus#8**: module/class-level ``pytest.mark.*`` propagation
+  now requires the target function to qualify as a test. Previously
+  a module ``pytestmark = pytest.mark.verifies("eq-1")`` tagged
+  **every** function in the file — including private helpers like
+  ``_build_homogeneous_mesh`` — and ``write_verifies_edges`` then
+  wrote spurious ``tests`` edges from those helpers to the
+  equation. ORPHEUS's declared coverage inflated by ~5-10% because
+  of this. Inherited markers are now gated on ``is_test=True``
+  (name matches ``test``/``test_*`` AND the file matches the
+  project's test-pattern globs). Function-level decorators still
+  apply unconditionally.
+
+### Notes
+
+- 272 → 281 tests (+9). New assertions split across
+  ``test_registry.py`` (+4 write-time dedup), ``test_query.py``
+  (+2 query-time dedup), and ``test_ast_analyzer.py`` (+3
+  helper-propagation regressions).
+- No API or schema changes. Drop-in upgrade from 0.8.0.
+- The ``_visit_source`` helper in ``tests/test_ast_analyzer.py``
+  gains an ``is_test_file`` parameter so Session 2 propagation
+  tests can keep exercising their contract under the tighter gate.
+
 ## 0.8.0 — 2026-04-13
 
 Session 3 of the ORPHEUS V&V integration: non-LLM verification

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sphinxcontrib-nexus"
-version = "0.8.0"
+version = "0.8.1"
 description = "Unified code + documentation knowledge graph from Sphinx builds and Python AST analysis"
 readme = "README.md"
 license = "MIT"

--- a/sphinxcontrib/nexus/__init__.py
+++ b/sphinxcontrib/nexus/__init__.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 logger = logging.getLogger(__name__)
 

--- a/sphinxcontrib/nexus/ast_analyzer.py
+++ b/sphinxcontrib/nexus/ast_analyzer.py
@@ -656,6 +656,14 @@ class CodeVisitor(ast.NodeVisitor):
         # pytest-marker fields. Function-level markers win over any
         # class- or module-level pytestmark stashed in the scope, so we
         # layer them: module (lowest) → class → function (highest).
+        #
+        # Inherited markers (module and class scope) only propagate to
+        # functions that qualify as tests. A helper like
+        # ``_build_homogeneous_mesh`` living in a test module must NOT
+        # pick up the module's ``pytestmark = pytest.mark.verifies(...)``
+        # — inheriting it would write spurious TESTS edges from the
+        # helper and inflate declared coverage. Function-level
+        # decorators are always respected because they're explicit.
         meta: dict[str, object] = {
             "file_path": self._file_path,
             "lineno": node.lineno,
@@ -664,11 +672,10 @@ class CodeVisitor(ast.NodeVisitor):
         }
         if is_test:
             meta["is_test"] = True
-
-        if self._module_pytest_meta:
-            meta.update(self._module_pytest_meta)
-        if self._current_class_pytest_meta:
-            meta.update(self._current_class_pytest_meta)
+            if self._module_pytest_meta:
+                meta.update(self._module_pytest_meta)
+            if self._current_class_pytest_meta:
+                meta.update(self._current_class_pytest_meta)
         if node.decorator_list:
             meta["decorators"] = tuple(
                 _render_decorator(dec) for dec in node.decorator_list

--- a/sphinxcontrib/nexus/directives.py
+++ b/sphinxcontrib/nexus/directives.py
@@ -243,10 +243,15 @@ def apply_pending_edges(
                 else EdgeType.IMPLEMENTS.value
             )
 
-            # Idempotent: skip if an equivalent directive edge already exists.
+            # Skip if ANY explicit edge already links this pair on
+            # the same edge type — registry, marker, a prior replay,
+            # or any future explicit source. Inference-sourced edges
+            # (``source="inferred"``) are weak and don't block the
+            # directive's deterministic assertion from joining them.
             existing = graph.get_edge_data(resolved, eq_id, default={})
             if any(
-                d.get("type") == edge_type and d.get("source") == "directive"
+                d.get("type") == edge_type
+                and d.get("source") not in (None, "inferred")
                 for d in existing.values()
             ):
                 continue

--- a/sphinxcontrib/nexus/merge.py
+++ b/sphinxcontrib/nexus/merge.py
@@ -217,12 +217,18 @@ def write_verifies_edges(g: "nx.MultiDiGraph") -> int:
                     label, node_id, eq_id,
                 )
                 continue
-            # Skip if this exact declared edge already exists (rebuilds
-            # on a pre-populated graph should be idempotent).
+            # Skip if ANY explicit TESTS edge already links this
+            # (test, equation) pair — registry, directive, a prior
+            # run of this pass, or any future explicit source. A
+            # ``source="inferred"`` edge is weak and is allowed to
+            # coexist with the marker-declared edge. This guard
+            # makes the pipeline pass-order irrelevant: whichever
+            # explicit source runs first wins, the later ones are
+            # no-ops.
             existing = g.get_edge_data(node_id, eq_id, default={})
             if any(
                 d.get("type") == EdgeType.TESTS.value
-                and d.get("source") == "pytest.mark.verifies"
+                and d.get("source") not in (None, "inferred")
                 for d in existing.values()
             ):
                 continue

--- a/sphinxcontrib/nexus/query.py
+++ b/sphinxcontrib/nexus/query.py
@@ -1021,12 +1021,28 @@ class GraphQuery:
         # Index 3: code → direct test callers (1-hop heuristic).
         code_to_1hop_tests: dict[str, list[str]] = {}
 
+        # Query-time dedup: multiple explicit edges can link the same
+        # ``(source, target)`` pair — e.g. a registry entry that was
+        # written before write-time dedup was hardened, or a graph
+        # loaded from an older nexus version. Track seen pairs per
+        # edge-type so each (code, equation) or (test, equation)
+        # relationship contributes at most one entry to the coverage
+        # result.
+        _implements_seen: set[tuple[str, str]] = set()
+        _declared_seen: set[tuple[str, str]] = set()
+
         for src, tgt, data in self._g.edges(data=True):
             etype = data.get("type", "")
             if etype == "implements":
+                if (src, tgt) in _implements_seen:
+                    continue
+                _implements_seen.add((src, tgt))
                 eq_to_code.setdefault(tgt, []).append(src)
                 code_to_eq.setdefault(src, []).append(tgt)
             elif etype == "tests":
+                if (src, tgt) in _declared_seen:
+                    continue
+                _declared_seen.add((src, tgt))
                 declared_tests.setdefault(tgt, []).append(
                     TestReference(
                         id=src,

--- a/sphinxcontrib/nexus/registry.py
+++ b/sphinxcontrib/nexus/registry.py
@@ -178,12 +178,16 @@ def _apply_verifications(
                     item_ctx, label, eq_id,
                 )
                 continue
-            # Idempotent: skip if an equivalent registry edge already
-            # exists for this (test, equation) pair.
+            # Skip if ANY explicit TESTS edge already links this
+            # (test, equation) pair — registry, marker, directive,
+            # or any future "explicit" source. An edge counts as
+            # explicit when its ``source`` is set and is not the
+            # string ``"inferred"``. Inference-sourced edges are
+            # weaker and the registry deliberately overrides them.
             existing = g.get_edge_data(test_id, eq_id, default={})
             if any(
                 d.get("type") == EdgeType.TESTS.value
-                and d.get("source") == "registry"
+                and d.get("source") not in (None, "inferred")
                 for d in existing.values()
             ):
                 continue
@@ -241,10 +245,15 @@ def _apply_implementations(
                     item_ctx, label, eq_id,
                 )
                 continue
+            # Skip if ANY explicit IMPLEMENTS edge already links the
+            # pair — registry re-runs, directive-sourced edges, or
+            # future sources are all honored. Inference-sourced edges
+            # (``source="inferred"``) are weak and the registry's
+            # deterministic assertion is allowed to coexist with them.
             existing = g.get_edge_data(fn_id, eq_id, default={})
             if any(
                 d.get("type") == EdgeType.IMPLEMENTS.value
-                and d.get("source") == "registry"
+                and d.get("source") not in (None, "inferred")
                 for d in existing.values()
             ):
                 continue

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -150,9 +150,13 @@ def test_init_file(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _visit_source(source: str, module_name: str = "testmod") -> CodeVisitor:
+def _visit_source(
+    source: str,
+    module_name: str = "testmod",
+    is_test_file: bool = False,
+) -> CodeVisitor:
     tree = ast.parse(source)
-    visitor = CodeVisitor(module_name, "test.py")
+    visitor = CodeVisitor(module_name, "test.py", is_test_file=is_test_file)
     visitor.visit(tree)
     return visitor
 
@@ -429,7 +433,7 @@ def test_class_level_decorator_propagates_to_methods():
         "class TestBalance:\n"
         "    def test_zero_residual(self): pass\n"
     )
-    v = _visit_source(src)
+    v = _visit_source(src, is_test_file=True)
     node = _find_node(
         v, "py:method:testmod.TestBalance.test_zero_residual"
     )
@@ -446,7 +450,7 @@ def test_method_level_decorator_overrides_class():
         "    def test_integration(self): pass\n"
         "    def test_inherits(self): pass\n"
     )
-    v = _visit_source(src)
+    v = _visit_source(src, is_test_file=True)
     overridden = _find_node(
         v, "py:method:testmod.TestBalance.test_integration"
     )
@@ -465,7 +469,7 @@ def test_class_pytestmark_assignment_propagates():
         "    pytestmark = pytest.mark.l2\n"
         "    def test_one(self): pass\n"
     )
-    v = _visit_source(src)
+    v = _visit_source(src, is_test_file=True)
     node = _find_node(v, "py:method:testmod.TestStuff.test_one")
     assert node.metadata["vv_level"] == "L2"
 
@@ -478,7 +482,7 @@ def test_module_pytestmark_propagates():
         "def test_one(): pass\n"
         "def test_two(): pass\n"
     )
-    v = _visit_source(src)
+    v = _visit_source(src, is_test_file=True)
     for name in ("test_one", "test_two"):
         node = _find_node(v, f"py:function:testmod.{name}")
         assert node.metadata["vv_level"] == "L2", name
@@ -491,7 +495,7 @@ def test_module_pytestmark_list_form():
         "\n"
         "def test_one(): pass\n"
     )
-    v = _visit_source(src)
+    v = _visit_source(src, is_test_file=True)
     node = _find_node(v, "py:function:testmod.test_one")
     assert node.metadata["vv_level"] == "L1"
     assert node.metadata["slow"] is True
@@ -505,9 +509,99 @@ def test_function_marker_beats_module_pytestmark():
         "@pytest.mark.l3\n"
         "def test_strict(): pass\n"
     )
-    v = _visit_source(src)
+    v = _visit_source(src, is_test_file=True)
     node = _find_node(v, "py:function:testmod.test_strict")
     assert node.metadata["vv_level"] == "L3"
+
+
+def test_module_pytestmark_does_not_propagate_to_helpers(tmp_path):
+    """Regression for nexus#8.
+
+    Module-level ``pytestmark = pytest.mark.verifies("eq-1")`` must
+    ONLY tag test functions (``is_test=True``). Private helpers
+    like ``_build_homogeneous_mesh`` that happen to live in the same
+    file must not inherit ``verifies`` metadata — otherwise
+    ``write_verifies_edges`` writes spurious TESTS edges and the
+    declared-coverage count inflates.
+
+    We run this through ``analyze_directory`` (not ``_visit_source``
+    alone) so the ``is_test_file`` detection fires correctly via
+    ``nexus_test_patterns``.
+    """
+    test_file = tmp_path / "tests" / "test_solver.py"
+    test_file.parent.mkdir()
+    test_file.write_text(
+        "import pytest\n"
+        "pytestmark = pytest.mark.verifies('eq-transport')\n"
+        "\n"
+        "def _build_homogeneous_mesh():\n"
+        "    return object()\n"
+        "\n"
+        "def test_transport():\n"
+        "    mesh = _build_homogeneous_mesh()\n"
+        "    assert mesh is not None\n"
+    )
+    graph = analyze_directory(tmp_path, exclude_patterns=[])
+    nodes = dict(graph.nxgraph.nodes(data=True))
+
+    test_node = nodes["py:function:tests.test_solver.test_transport"]
+    helper_node = nodes["py:function:tests.test_solver._build_homogeneous_mesh"]
+
+    # The real test inherits the module-level mark.
+    assert test_node.get("verifies") == ("eq-transport",)
+    # The helper MUST NOT — it's is_test=False.
+    assert "verifies" not in helper_node, (
+        f"helper function inherited module pytestmark: {helper_node}"
+    )
+    assert helper_node.get("is_test") is not True
+
+
+def test_module_pytestmark_vv_level_does_not_propagate_to_helpers(tmp_path):
+    test_file = tmp_path / "tests" / "test_solver.py"
+    test_file.parent.mkdir()
+    test_file.write_text(
+        "import pytest\n"
+        "pytestmark = pytest.mark.l1\n"
+        "\n"
+        "def _shared_setup():\n"
+        "    pass\n"
+        "\n"
+        "def test_it():\n"
+        "    _shared_setup()\n"
+    )
+    graph = analyze_directory(tmp_path, exclude_patterns=[])
+    nodes = dict(graph.nxgraph.nodes(data=True))
+
+    assert nodes["py:function:tests.test_solver.test_it"].get("vv_level") == "L1"
+    # Helper must have no vv_level from the module scope.
+    helper = nodes["py:function:tests.test_solver._shared_setup"]
+    assert "vv_level" not in helper, helper
+
+
+def test_class_level_mark_does_not_propagate_to_private_methods(tmp_path):
+    test_file = tmp_path / "tests" / "test_solver.py"
+    test_file.parent.mkdir()
+    test_file.write_text(
+        "import pytest\n"
+        "\n"
+        "@pytest.mark.l0\n"
+        "class TestSolver:\n"
+        "    def _shared_fixture(self):\n"
+        "        return 1\n"
+        "\n"
+        "    def test_something(self):\n"
+        "        assert self._shared_fixture() == 1\n"
+    )
+    graph = analyze_directory(tmp_path, exclude_patterns=[])
+    nodes = dict(graph.nxgraph.nodes(data=True))
+
+    assert nodes[
+        "py:method:tests.test_solver.TestSolver.test_something"
+    ].get("vv_level") == "L0"
+    helper = nodes[
+        "py:method:tests.test_solver.TestSolver._shared_fixture"
+    ]
+    assert "vv_level" not in helper, helper
 
 
 def test_nested_class_does_not_leak_markers_upward():
@@ -520,7 +614,7 @@ def test_nested_class_does_not_leak_markers_upward():
         "        def test_inside(self): pass\n"
         "    def test_outside(self): pass\n"
     )
-    v = _visit_source(src)
+    v = _visit_source(src, is_test_file=True)
     inner = _find_node(v, "py:method:testmod.Outer.Inner.test_inside")
     outer = _find_node(v, "py:method:testmod.Outer.test_outside")
     assert inner.metadata["vv_level"] == "L2"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -403,6 +403,62 @@ def test_coverage_documented_when_no_code_no_tests():
     assert entry.status == "documented"
 
 
+def test_coverage_dedupes_duplicate_tests_edges():
+    """Regression for nexus#7 (query-time layer).
+
+    When two TESTS edges link the same (test, equation) pair —
+    e.g. one from ``pytest.mark.verifies`` and one from a registry
+    entry that was written before the write-time dedup was
+    hardened — the coverage result must collapse them to a single
+    ``TestReference``. Otherwise the per-equation test count
+    double-counts (the exact 86 → 87 bug from the 0.8.0 cross-
+    validation).
+    """
+    def build(g):
+        g.add_node("math:equation:eq-dup", type="equation", name="eq-dup",
+                   display_name="(dup)", domain="math", docname="theory")
+        g.add_node("py:function:test_t", type="function", name="test_t",
+                   display_name="test_t", domain="py", is_test=True)
+        # Two explicit TESTS edges from different sources — this is
+        # the bug shape the write-time fix prevents, but the query
+        # layer must still be robust to a graph loaded from an older
+        # nexus version that has this state.
+        g.add_edge("py:function:test_t", "math:equation:eq-dup",
+                   type="tests", source="pytest.mark.verifies",
+                   confidence=1.0)
+        g.add_edge("py:function:test_t", "math:equation:eq-dup",
+                   type="tests", source="registry", confidence=1.0)
+
+    g = _coverage_graph(build)
+    cov = GraphQuery(g).verification_coverage()
+    entry = _find_entry(cov, "math:equation:eq-dup")
+    assert len(entry.tests) == 1
+    assert entry.tests[0].id == "py:function:test_t"
+
+
+def test_coverage_dedupes_duplicate_implements_edges():
+    """Same regression shape for IMPLEMENTS: duplicate edges must not
+    inflate ``implementing_code``."""
+    def build(g):
+        g.add_node("math:equation:eq-impl-dup", type="equation",
+                   name="eq-impl-dup", display_name="(impl-dup)",
+                   domain="math", docname="theory")
+        g.add_node("py:function:impl", type="function", name="impl",
+                   display_name="impl", domain="py")
+        g.add_edge("py:function:impl", "math:equation:eq-impl-dup",
+                   type="implements", source="directive",
+                   confidence=1.0)
+        g.add_edge("py:function:impl", "math:equation:eq-impl-dup",
+                   type="implements", source="registry",
+                   confidence=1.0)
+
+    g = _coverage_graph(build)
+    cov = GraphQuery(g).verification_coverage()
+    entry = _find_entry(cov, "math:equation:eq-impl-dup")
+    assert len(entry.implementing_code) == 1
+    assert entry.implementing_code[0].id == "py:function:impl"
+
+
 def test_coverage_implemented_when_code_but_no_tests():
     def build(g):
         g.add_node("math:equation:eq-5", type="equation", name="eq-5",

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -187,6 +187,125 @@ implementations:
 # ---------------------------------------------------------------------------
 
 
+def test_registry_skips_pair_with_existing_marker_edge(tmp_path):
+    """Regression for nexus#7.
+
+    When a test already carries a ``pytest.mark.verifies``-sourced
+    TESTS edge for a given equation, the registry must not write a
+    second, parallel TESTS edge. The meaning is the same — both
+    sources assert "this test verifies this equation" — and two
+    edges inflate the per-equation test count.
+    """
+    path = _write_yaml(tmp_path, """
+version: 1
+verifications:
+  - test: py:function:tests.test_solver.test_solve
+    verifies: [eq-1]
+""")
+    g = _base_graph()
+    # Simulate write_verifies_edges already having written the edge
+    # from the AST marker pass (which runs BEFORE the registry).
+    g.add_edge(
+        "py:function:tests.test_solver.test_solve",
+        "math:equation:eq-1",
+        type="tests",
+        source="pytest.mark.verifies",
+        confidence=1.0,
+    )
+
+    written = load_registry(path, g)
+    assert written == 0, (
+        "registry wrote a duplicate TESTS edge on top of an "
+        "existing pytest.mark.verifies-sourced edge"
+    )
+    tests_edges = [
+        (s, t, d.get("source"))
+        for s, t, d in g.edges(data=True)
+        if d.get("type") == "tests"
+    ]
+    assert len(tests_edges) == 1, tests_edges
+    # The existing (marker-sourced) edge must survive.
+    assert tests_edges[0][2] == "pytest.mark.verifies"
+
+
+def test_registry_skips_pair_with_existing_directive_edge(tmp_path):
+    """Same regression, but for directive-sourced edges.
+
+    ``.. verifies::`` directives write TESTS edges with
+    ``source="directive"``; the registry must honor those too.
+    """
+    path = _write_yaml(tmp_path, """
+version: 1
+verifications:
+  - test: py:function:tests.test_solver.test_solve
+    verifies: [eq-1]
+""")
+    g = _base_graph()
+    g.add_edge(
+        "py:function:tests.test_solver.test_solve",
+        "math:equation:eq-1",
+        type="tests",
+        source="directive",
+        confidence=1.0,
+    )
+
+    assert load_registry(path, g) == 0
+
+
+def test_registry_skips_implements_pair_with_existing_explicit_edge(tmp_path):
+    """Registry implementations also must not duplicate a pre-existing
+    explicit IMPLEMENTS edge from a directive."""
+    path = _write_yaml(tmp_path, """
+version: 1
+implementations:
+  - function: py:function:solver.solve
+    implements: [eq-1]
+""")
+    g = _base_graph()
+    g.add_edge(
+        "py:function:solver.solve",
+        "math:equation:eq-1",
+        type="implements",
+        source="directive",
+        confidence=1.0,
+    )
+
+    assert load_registry(path, g) == 0
+
+
+def test_registry_still_writes_over_inferred_edge(tmp_path):
+    """Inference-sourced edges (``source="inferred"``) are NOT
+    considered explicit — the registry's deterministic assertion
+    should replace them rather than defer."""
+    path = _write_yaml(tmp_path, """
+version: 1
+implementations:
+  - function: py:function:solver.solve
+    implements: [eq-1]
+""")
+    g = _base_graph()
+    g.add_edge(
+        "py:function:solver.solve",
+        "math:equation:eq-1",
+        type="implements",
+        source="inferred",
+        confidence=0.7,
+    )
+
+    written = load_registry(path, g)
+    assert written == 1
+    # Both edges now coexist — the inferred one stays, the registry
+    # edge is added. Consumers that care about the difference can
+    # read the ``source`` attribute.
+    pair_edges = [
+        d
+        for _, _, d in g.edges(data=True)
+        if d.get("type") == "implements"
+    ]
+    assert len(pair_edges) == 2
+    assert {e["source"] for e in pair_edges} == {"inferred", "registry"}
+
+
 def test_registry_is_idempotent(tmp_path):
     path = _write_yaml(tmp_path, """
 version: 1


### PR DESCRIPTION
Two bug fixes caught by the ORPHEUS cross-validation of 0.8.0. Both commits land as standalone TDD changes (failing test → fix → green), followed by a release commit.

Closes #7, closes #8.

## Fix #7 — explicit-source edge dedup (`d32c1a7`)

**Repro**: the ORPHEUS ``matrix-eigenvalue`` equation's test count jumps from 86 to 87 when the same test is covered by both ``@pytest.mark.verifies("matrix-eigenvalue")`` and a registry ``verifications:`` entry.

**Root cause**: each write-time pass only checked for duplication against its OWN source. So the pipeline

\`\`\`
write_verifies_edges (pytest.mark) → apply_pending_edges (directive) → load_registry → _infer_implements
\`\`\`

happily wrote a second TESTS edge with ``source="registry"`` on top of the existing ``source="pytest.mark.verifies"`` one, because the registry guard was ``source == "registry"`` specifically.

**Fix**: all four passes now skip if ANY edge of the same type has a non-inference source already present:

\`\`\`python
if any(
    d.get("type") == edge_type
    and d.get("source") not in (None, "inferred")
    for d in existing.values()
):
    continue
\`\`\`

``source="inferred"`` edges remain weak and can coexist with any explicit assertion — their confidence is 0.7 vs 1.0 and the ``source`` attr lets consumers differentiate. This also makes the pipeline pass-order irrelevant for correctness (previously the write-ordering was load-bearing).

**Defense in depth**: query-time dedup layer in ``verification_coverage`` tracks seen ``(src, tgt)`` pairs per edge-type. A graph loaded from an older nexus release that still carries duplicates will collapse them at read time — ``verification_coverage`` returns at most one ``TestReference`` per ``(test, equation)`` pair regardless of how many edges survive.

**Tests**: 6 new assertions
- 4 write-time regressions in ``test_registry.py`` covering every source-pair combination
- 2 query-time regressions in ``test_query.py`` reproducing the 86 → 87 shape directly

## Fix #8 — helper over-tagging from module/class pytestmark (`95c99bf`)

**Repro**: a test file with ``pytestmark = pytest.mark.verifies("eq-transport")`` at the top and a ``_build_homogeneous_mesh`` private helper underneath — the helper gets tagged ``verifies=("eq-transport",)`` and ``write_verifies_edges`` then writes a spurious TESTS edge from the helper to the equation. ~5-10% inflation on ORPHEUS's declared coverage counts.

**Root cause**: ``_visit_function`` layered ``_module_pytest_meta`` and ``_current_class_pytest_meta`` onto every function node unconditionally, before the ``is_test`` check.

**Fix**: gate the inherited-marker layering on ``is_test``. Function-level decorators continue to apply unconditionally — they're explicit opt-in, not inheritance.

\`\`\`python
if is_test:
    meta["is_test"] = True
    if self._module_pytest_meta:
        meta.update(self._module_pytest_meta)
    if self._current_class_pytest_meta:
        meta.update(self._current_class_pytest_meta)
if node.decorator_list:
    meta["decorators"] = tuple(...)
    meta.update(_parse_pytest_markers(node.decorator_list))
\`\`\`

**Tests**: 3 new regressions in ``test_ast_analyzer.py``, plus 6 Session 2 propagation tests updated to explicitly pass ``is_test_file=True`` to the ``_visit_source`` helper (which now exposes that parameter).

## Test status

272 → 281 (+9). All green.

## Verification

\`\`\`bash
pip install --upgrade sphinxcontrib-nexus==0.8.1  # after tag
cd /workspaces/ORPHEUS
rm -rf docs/_build && sphinx-build docs docs/_build/html -q
\`\`\`

Expected changes from 0.8.0:

- ``matrix-eigenvalue`` test count drops from 87 → 86 (#7 fix: the duplicate edge is gone)
- Declared TESTS edge count drops by however many helper-inflation edges #8 was producing. Your ~5-10% figure from the issue gives a rough delta estimate.
- Coverage summary may see ``verified`` tick down slightly and ``implemented`` tick up if any equation was ONLY "verified" via a helper-tagged TESTS edge that's now gone. Real equations still reach ``verified`` via their legitimate pytest.mark-tagged tests.

No API or schema changes. Drop-in upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)