### PR TITLE
Add LLM-orientation fields to session_briefing (v0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 All notable changes to sphinxcontrib-nexus.
 
+## 0.10.0 — 2026-04-14
+
+LLM-orientation pass on ``session_briefing``. Three additive fields
+teach the agent the node-ID grammar on the first turn, surface the
+handful of nodes most likely to be queried next, and emit a paste-
+ready ``ToolSearch`` invocation for Nexus's deferred MCP tools.
+Drop-in upgrade from 0.9.0: no existing field was removed or
+re-shaped.
+
+### Added
+
+- **``id_grammar``** in ``BriefingResult``. For each
+  ``(domain, type)`` pair actually present in the graph (excluding
+  the noise types ``external`` and ``unresolved``), emits one
+  representative node with the median degree in that bucket.
+  Max-degree nodes are already in ``god_nodes``; min-degree nodes
+  are obscure; the median is the useful teaching example. Examples
+  are sorted by ``(domain, type)`` ascending and are deterministic
+  across calls on an unchanged graph.
+- **``hot_nodes``** in ``BriefingResult``. Nodes that (a) appear in
+  ``recent_changes`` (same data ``session_briefing`` already uses,
+  i.e. ``detect_changes(scope="branch")`` against main/master — no
+  separate window), (b) have degree at or above the graph median
+  so "hot" implies both recent *and* central, and (c) are not
+  already in ``god_nodes[:5]`` (to avoid duplicating the signal
+  that field already carries). Top 5 by degree, tiebreak on id.
+  Each entry carries a free-form ``reason`` drawn from a small
+  stable vocabulary (``"modified in current branch"``, etc).
+- **``preload_hint``** in ``BriefingResult``. A static, graph-
+  independent ``select:`` string listing the eight most-used Nexus
+  MCP tools (``query``, ``callers``, ``callees``, ``context``,
+  ``impact``, ``provenance_chain``, ``shortest_path``,
+  ``neighbors``). Paste it into a single ``ToolSearch`` call on
+  the first turn that touches Nexus instead of loading schemas
+  one tool at a time.
+
+All three fields flow through the existing ``to_dict`` /
+``asdict`` path as nested dataclasses, so ``session_briefing`` MCP
+and CLI responses pick them up automatically — no serializer
+changes required.
+
+### Round-trip contract verified
+
+Before wiring ``id_grammar``, ran an empirical probe that walked
+every ``god_nodes`` entry from a realistic briefing and fed its
+``id`` back into ``assemble_context``. All five round-tripped
+cleanly — confirming that ``NodeResult.id`` (the
+``<domain>:<type>:<name>`` graph key) is directly accepted by
+``context`` and, by extension, every other MCP tool that takes a
+node id. The contract that ``id_grammar.examples[*].id`` is
+usable verbatim now has a test
+(``test_briefing_id_grammar_round_trip``) pinning it.
+
 ## 0.9.0 — 2026-04-13
 
 Session 4 of the ORPHEUS V&V integration: infrastructure hardening.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sphinxcontrib-nexus"
-version = "0.9.0"
+version = "0.10.0"
 description = "Unified code + documentation knowledge graph from Sphinx builds and Python AST analysis"
 readme = "README.md"
 license = "MIT"

--- a/sphinxcontrib/nexus/__init__.py
+++ b/sphinxcontrib/nexus/__init__.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 logger = logging.getLogger(__name__)
 

--- a/sphinxcontrib/nexus/query.py
+++ b/sphinxcontrib/nexus/query.py
@@ -232,6 +232,50 @@ class StalenessResult:
 
 
 @dataclass
+class IdGrammarExample:
+    """One representative node ID for a (domain, type) pair."""
+
+    domain: str
+    type: str
+    id: str
+    display_name: str
+
+
+@dataclass
+class IdGrammar:
+    """Representative node IDs teaching the LLM the ID grammar."""
+
+    description: str
+    examples: list[IdGrammarExample]
+
+
+@dataclass
+class HotNode:
+    """A node likely to be queried next in the current session."""
+
+    id: str
+    type: str
+    degree: int
+    reason: str
+
+
+@dataclass
+class HotNodes:
+    """Recently-touched, high-degree nodes worth surfacing early."""
+
+    description: str
+    nodes: list[HotNode]
+
+
+@dataclass
+class PreloadHint:
+    """A static ToolSearch invocation to preload common Nexus tools."""
+
+    description: str
+    tool_search_call: str
+
+
+@dataclass
 class BriefingResult:
     """Session briefing for an AI agent."""
 
@@ -242,6 +286,15 @@ class BriefingResult:
     recent_changes: list[ChangeEntry]
     unresolved_count: int
     external_count: int
+    id_grammar: IdGrammar = field(
+        default_factory=lambda: IdGrammar(description="", examples=[]),
+    )
+    hot_nodes: HotNodes = field(
+        default_factory=lambda: HotNodes(description="", nodes=[]),
+    )
+    preload_hint: PreloadHint = field(
+        default_factory=lambda: PreloadHint(description="", tool_search_call=""),
+    )
 
 
 @dataclass
@@ -1561,6 +1614,25 @@ class GraphQuery:
             if a.get("type") == "external"
         )
 
+        id_grammar = self._compute_id_grammar()
+        hot_nodes = self._compute_hot_nodes(
+            changes_result.changed_symbols,
+            god_top_ids={n.id for n in top_nodes},
+        )
+        preload_hint = PreloadHint(
+            description=(
+                "Nexus MCP tool schemas are deferred (not loaded by default in "
+                "LLM sessions). Paste the tool_search_call below into a single "
+                "ToolSearch call on the first turn that uses Nexus — this loads "
+                "the eight most-common tools in one round-trip instead of staged."
+            ),
+            tool_search_call=(
+                "select:mcp__nexus__query,mcp__nexus__callers,mcp__nexus__callees,"
+                "mcp__nexus__context,mcp__nexus__impact,mcp__nexus__provenance_chain,"
+                "mcp__nexus__shortest_path,mcp__nexus__neighbors"
+            ),
+        )
+
         return BriefingResult(
             graph_stats=stats_result,
             god_nodes=top_nodes,
@@ -1569,7 +1641,109 @@ class GraphQuery:
             recent_changes=changes_result.changed_symbols[:10],
             unresolved_count=unresolved,
             external_count=external,
+            id_grammar=id_grammar,
+            hot_nodes=hot_nodes,
+            preload_hint=preload_hint,
         )
+
+    def _compute_id_grammar(self) -> IdGrammar:
+        """Pick one median-degree node per (domain, type) pair as an example.
+
+        Excludes the ``external`` and ``unresolved`` types — already
+        surfaced as counts elsewhere and not useful for constructing
+        queries.
+        """
+        description = (
+            "One representative node ID per (domain, type) pair present in "
+            "the graph. Use these to learn the ID grammar for constructing "
+            "queries against Nexus tools that accept node IDs (callers, "
+            "callees, context, impact, provenance_chain, shortest_path, "
+            "neighbors). Each id is a verbatim graph key — it round-trips "
+            "through context(id=...) without transformation."
+        )
+
+        buckets: dict[tuple[str, str], list[str]] = {}
+        for nid, attrs in self._g.nodes(data=True):
+            ntype = attrs.get("type", "")
+            if ntype in ("external", "unresolved"):
+                continue
+            domain = attrs.get("domain", "")
+            buckets.setdefault((domain, ntype), []).append(nid)
+
+        examples: list[IdGrammarExample] = []
+        for (domain, ntype) in sorted(buckets.keys()):
+            ids = buckets[(domain, ntype)]
+            if not ids:
+                continue
+            # Sort by (degree asc, id asc); pick the median element.
+            ranked = sorted(ids, key=lambda n: (self._g.degree(n), n))
+            pick = ranked[len(ranked) // 2]
+            attrs = self._g.nodes[pick]
+            examples.append(IdGrammarExample(
+                domain=domain,
+                type=ntype,
+                id=pick,
+                display_name=attrs.get("display_name", "") or attrs.get("name", ""),
+            ))
+
+        return IdGrammar(description=description, examples=examples)
+
+    def _compute_hot_nodes(
+        self,
+        changed_symbols: list[ChangeEntry],
+        god_top_ids: set[str],
+    ) -> HotNodes:
+        """Rank recently-changed, high-degree nodes as likely next queries.
+
+        ``recent_changes`` in the briefing is computed from a git diff of
+        the current branch vs its merge base on main/master (see
+        :meth:`detect_changes` with ``scope="branch"``). This function uses
+        the same data — there is no separate time/commit window.
+        """
+        description = (
+            "Nodes most likely to be queried in this session. Computed from "
+            "symbols changed in the current branch vs main/master, filtered "
+            "to those with degree above the graph median (so 'hot' means "
+            "both recent and central). Empty on a fresh branch or when all "
+            "changes land on obscure leaf symbols."
+        )
+
+        if not changed_symbols:
+            return HotNodes(description=description, nodes=[])
+
+        # Median degree over the whole graph, used as a centrality floor.
+        all_degrees = sorted(d for _, d in self._g.degree())
+        if not all_degrees:
+            return HotNodes(description=description, nodes=[])
+        median_degree = all_degrees[len(all_degrees) // 2]
+
+        reason_map = {
+            "added": "added in current branch",
+            "modified": "modified in current branch",
+            "deleted": "deleted in current branch",
+        }
+
+        seen: set[str] = set()
+        candidates: list[HotNode] = []
+        for entry in changed_symbols:
+            nid = entry.node.id
+            if nid in seen or nid in god_top_ids:
+                continue
+            if nid not in self._g:
+                continue
+            deg = self._g.degree(nid)
+            if deg < median_degree:
+                continue
+            seen.add(nid)
+            candidates.append(HotNode(
+                id=nid,
+                type=entry.node.type,
+                degree=deg,
+                reason=reason_map.get(entry.change_type, "changed in current branch"),
+            ))
+
+        candidates.sort(key=lambda h: (-h.degree, h.id))
+        return HotNodes(description=description, nodes=candidates[:5])
 
     # ------------------------------------------------------------------
     # Feature 5: Minimum Retest Set

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -363,6 +363,191 @@ def test_session_briefing(dream_graph):
     assert len(result.god_nodes) > 0
 
 
+# ---------------------------------------------------------------------------
+# session_briefing: LLM-orientation fields (id_grammar / hot_nodes / preload_hint)
+# ---------------------------------------------------------------------------
+
+
+def test_briefing_id_grammar_shape(dream_graph):
+    q = GraphQuery(dream_graph)
+    grammar = q.session_briefing().id_grammar
+    assert grammar.description
+    assert isinstance(grammar.examples, list)
+    assert len(grammar.examples) > 0
+    seen_pairs = set()
+    for ex in grammar.examples:
+        assert ex.id
+        assert ex.type
+        pair = (ex.domain, ex.type)
+        assert pair not in seen_pairs, f"duplicate pair {pair}"
+        seen_pairs.add(pair)
+
+
+def test_briefing_id_grammar_excludes_external_and_unresolved(dream_graph):
+    q = GraphQuery(dream_graph)
+    grammar = q.session_briefing().id_grammar
+    for ex in grammar.examples:
+        assert ex.type not in ("external", "unresolved"), (
+            f"external/unresolved leaked into id_grammar: {ex.id}"
+        )
+
+
+def test_briefing_id_grammar_round_trip(dream_graph):
+    """Every example id must be directly usable by context()."""
+    from sphinxcontrib.nexus._serialize import assemble_context
+
+    q = GraphQuery(dream_graph)
+    grammar = q.session_briefing().id_grammar
+    for ex in grammar.examples:
+        result = assemble_context(q, ex.id)
+        assert "error" not in result, f"round-trip failed for {ex.id}: {result}"
+        assert result["node"]["id"] == ex.id
+
+
+def test_briefing_id_grammar_sorted(dream_graph):
+    q = GraphQuery(dream_graph)
+    grammar = q.session_briefing().id_grammar
+    pairs = [(ex.domain, ex.type) for ex in grammar.examples]
+    assert pairs == sorted(pairs)
+
+
+def test_briefing_id_grammar_empty_graph():
+    q = GraphQuery(nx.MultiDiGraph())
+    grammar = q.session_briefing().id_grammar
+    assert grammar.examples == []
+    assert grammar.description  # description stays populated
+
+
+def test_briefing_id_grammar_only_external_unresolved():
+    g = nx.MultiDiGraph()
+    g.add_node("py:external:foo", type="external", name="foo", domain="py")
+    g.add_node("std:cite:Bar", type="unresolved", name="Bar", domain="std")
+    q = GraphQuery(g)
+    grammar = q.session_briefing().id_grammar
+    assert grammar.examples == []
+
+
+def test_briefing_hot_nodes_empty_without_project_root(dream_graph):
+    q = GraphQuery(dream_graph)
+    hot = q.session_briefing().hot_nodes
+    assert hot.description
+    assert hot.nodes == []
+
+
+def _init_git_branch(tmp_path, file_rel, new_content):
+    """Init a git repo, commit file, switch to feature branch, modify it."""
+    subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=tmp_path, capture_output=True)
+    f = tmp_path / file_rel
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("def placeholder(): pass\n")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "checkout", "-b", "feature"], cwd=tmp_path, capture_output=True)
+    f.write_text(new_content)
+    subprocess.run(["git", "commit", "-am", "change"], cwd=tmp_path, capture_output=True)
+    return f
+
+
+def test_briefing_hot_nodes_with_changes(tmp_path):
+    """Recently-changed high-degree nodes should surface in hot_nodes."""
+    # 5 untouched hubs (degrees 20..16) occupy god_top[:5]. changed_hub
+    # has degree 5 — above graph median (1) but well below god_top — and
+    # lives in a changed file, so it should appear in hot_nodes.
+    g = nx.MultiDiGraph()
+    for h in range(5):
+        hub = f"py:function:pkg.untouched_hub{h}"
+        g.add_node(hub, type="function", name=f"pkg.untouched_hub{h}", domain="py")
+        for i in range(20 - h):
+            leaf = f"py:function:pkg.u{h}_leaf{i}"
+            g.add_node(leaf, type="function", name=leaf, domain="py")
+            g.add_edge(hub, leaf, type="calls")
+
+    changed_file = tmp_path / "pkg" / "changed.py"
+    g.add_node("py:function:pkg.changed_hub", type="function",
+               name="pkg.changed_hub", domain="py", file_path=str(changed_file))
+    for i in range(5):
+        leaf = f"py:function:pkg.c_leaf{i}"
+        g.add_node(leaf, type="function", name=f"pkg.c_leaf{i}", domain="py")
+        g.add_edge("py:function:pkg.changed_hub", leaf, type="calls")
+
+    _init_git_branch(tmp_path, "pkg/changed.py", "def changed_hub(): return 1\n")
+
+    q = GraphQuery(g)
+    briefing = q.session_briefing(project_root=tmp_path)
+    hot_ids = {n.id for n in briefing.hot_nodes.nodes}
+    assert "py:function:pkg.changed_hub" in hot_ids
+    target = next(
+        n for n in briefing.hot_nodes.nodes
+        if n.id == "py:function:pkg.changed_hub"
+    )
+    assert target.reason == "modified in current branch"
+    assert target.degree == 5
+    # And must not have collided with a god_top slot.
+    god_top = {n.id for n in briefing.god_nodes[:5]}
+    assert "py:function:pkg.changed_hub" not in god_top
+
+
+def test_briefing_hot_nodes_excludes_god_top(tmp_path):
+    """A node in god_nodes[:5] must not also appear in hot_nodes."""
+    hub_file = tmp_path / "pkg" / "hub.py"
+    g = nx.MultiDiGraph()
+    g.add_node("py:function:pkg.hub", type="function", name="pkg.hub",
+               domain="py", file_path=str(hub_file))
+    for i in range(3):
+        leaf = f"py:function:pkg.leaf{i}"
+        g.add_node(leaf, type="function", name=f"pkg.leaf{i}", domain="py")
+        g.add_edge("py:function:pkg.hub", leaf, type="calls")
+
+    _init_git_branch(tmp_path, "pkg/hub.py", "def hub(): return 1\n")
+
+    q = GraphQuery(g)
+    briefing = q.session_briefing(project_root=tmp_path)
+    god_top = {n.id for n in briefing.god_nodes[:5]}
+    hot_ids = {n.id for n in briefing.hot_nodes.nodes}
+    assert "py:function:pkg.hub" in god_top
+    assert "py:function:pkg.hub" not in hot_ids
+
+
+def test_briefing_preload_hint_is_static(dream_graph):
+    q = GraphQuery(dream_graph)
+    hint = q.session_briefing().preload_hint
+    assert hint.description
+    assert hint.tool_search_call.startswith("select:")
+    expected = {
+        "mcp__nexus__query", "mcp__nexus__callers", "mcp__nexus__callees",
+        "mcp__nexus__context", "mcp__nexus__impact",
+        "mcp__nexus__provenance_chain", "mcp__nexus__shortest_path",
+        "mcp__nexus__neighbors",
+    }
+    selection = set(hint.tool_search_call[len("select:"):].split(","))
+    assert selection == expected
+
+
+def test_briefing_deterministic(dream_graph):
+    """Two successive calls on an unchanged graph produce identical output."""
+    from sphinxcontrib.nexus._serialize import to_dict
+
+    q = GraphQuery(dream_graph)
+    a = to_dict(q.session_briefing())
+    b = to_dict(q.session_briefing())
+    assert a["id_grammar"] == b["id_grammar"]
+    assert a["hot_nodes"] == b["hot_nodes"]
+    assert a["preload_hint"] == b["preload_hint"]
+
+
+def test_briefing_backward_compatible_fields(dream_graph):
+    """All pre-existing fields must still be present and unchanged in shape."""
+    q = GraphQuery(dream_graph)
+    result = q.session_briefing()
+    for attr in (
+        "graph_stats", "god_nodes", "stale_docs", "coverage_gaps",
+        "recent_changes", "unresolved_count", "external_count",
+    ):
+        assert hasattr(result, attr)
+
+
 def test_retest_with_git(dream_graph, tmp_path):
     """Retest needs a git repo; verify it runs without crashing."""
     subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)


### PR DESCRIPTION
## Summary

Three additive fields on `BriefingResult` so an LLM starting a session can construct valid Nexus queries on the first turn without a preliminary lookup round:

- **`id_grammar`** — one median-degree representative node per `(domain, type)` pair actually present in the graph (excluding `external` / `unresolved`). Teaches the `<domain>:<type>:<name>` shape with examples that round-trip through `context()` verbatim. Sorted deterministically.
- **`hot_nodes`** — nodes appearing in `recent_changes` (reused from `detect_changes(scope="branch")` — same data the briefing already computes, no separate time/commit window), filtered to degree ≥ graph median so "hot" means both recent **and** central, and excluded from `god_nodes[:5]` to avoid duplicating that signal. Top 5 by degree, tiebreak on id.
- **`preload_hint`** — static `ToolSearch` `select:` string listing the 8 most-used Nexus MCP tools (`query`, `callers`, `callees`, `context`, `impact`, `provenance_chain`, `shortest_path`, `neighbors`). Pasted into a single `ToolSearch` call on the first turn that touches Nexus instead of loading schemas one at a time.

All three flow through the existing `to_dict` / `asdict` path as nested dataclasses — MCP and CLI responses pick them up automatically.

### Backward compatibility

No existing field was removed or reshaped. The three new fields are defaulted via `field(default_factory=...)` so existing `BriefingResult(...)` call sites keep working. Version bump is minor (`0.9.0` → `0.10.0`) because the payload grew.

### Round-trip contract, verified empirically

Before wiring `id_grammar`, I ran a probe against a realistic briefing that fed every `god_nodes[*].id` back into `assemble_context`. All 5 round-tripped cleanly — confirming `NodeResult.id` is the raw NetworkX key and nothing sits between briefing output and `context()` input. The contract is pinned by `test_briefing_id_grammar_round_trip`.

### Consumer install

ORPHEUS can pip-install directly from this branch to run its own acceptance protocol before merge:

```
pip install 'git+https://github.com/deOliveira-R/sphinxcontrib-nexus.git@briefing-llm-orientation-fields'
```

## Test plan

- [x] `pytest` — 328 tests pass locally (12 new, covering shape / sort / round-trip / external+unresolved exclusion / empty graph / noise-only graph / determinism / god_top exclusion / hot_nodes with real git diff / preload_hint static content / backward compatibility of pre-existing fields)
- [ ] **ORPHEUS 8-test acceptance protocol** from the spec:
  1. Schema test — three new top-level keys present
  2. Round-trip test — every `id_grammar.examples[*].id` works with `context`
  3. Round-trip test — every `hot_nodes.nodes[*].id` works with `context`
  4. Preload test — `ToolSearch` with the hint returns all 8 schemas
  5. Determinism test — two successive `session_briefing` calls hash-match on `id_grammar` + `hot_nodes`
  6. Noise test — no `external:*` or `unresolved:*` in `id_grammar`
  7. Size test — total payload under 5 KB (smoke test on dream-graph showed ~3.2 KB)
  8. Real-session smoke test — first Nexus query lands without a preceding `query` lookup

Merge only after the ORPHEUS acceptance protocol comes back clean.