### PR TITLE
feat: dead-reference detection — the silent doc-drift gate (40th MCP tool)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ All notable changes to sphinxcontrib-nexus.
 ### Dead-reference detection — the silent doc-drift gate
 
 A deleted or renamed symbol leaves its doc references behind, and Sphinx
-renders them as plain text with **no warning at any severity**. Measured on
-ORPHEUS: 212 project-rooted referenced phantoms, of which 36 named genuinely
-missing code. The graph already contained the signal (reference edges whose
-target reconciled to nothing); this release makes it precise enough to gate
-on and surfaces it (MCP tools 39 → 40).
+renders them as plain text with **no warning at any severity**. The graph
+already contained the signal (reference edges whose target reconciled to
+nothing), but on ORPHEUS the bucket ran ~83% false positives. This release
+makes it precise enough to gate on and surfaces it (MCP tools 39 → 40).
+Validated against ORPHEUS with import-resolution as ground truth: every
+reported Python target is either genuinely missing or a code-less
+README-only namespace directory; zero false positives on real code, and
+symbols that merely MOVED (old paths still referenced by unqualified
+docstring refs) resolve to their new homes instead of being reported.
 
 ### Added
 
@@ -41,6 +45,25 @@ on and surfaces it (MCP tools 39 → 40).
 
 ### Fixed
 
+- **Package-relative imports resolved one level short.** `ImportTracker`
+  anchored every relative import at the module's parent — correct for
+  `pkg/mod.py`, off by one inside a nested package's `__init__.py`, so
+  `from .directional import Quadrature` in
+  `orpheus/numerics/quadrature/__init__.py` resolved to
+  `orpheus.numerics.directional.Quadrature` (2,326 poisoned aliases on
+  ORPHEUS). This also silently mangled base-class and call-target
+  resolution in nested-package `__init__` modules, fabricating
+  dead-looking names for symbols that had merely moved.
+- **Subscripted generic bases dropped.** `class Full(Composite[A, B])`
+  produced no INHERITS edge, severing inherited-member resolution for
+  every `Generic`-parameterized class.
+- **Module-level docstrings were never scanned.** `visit_Module` skipped
+  reference extraction entirely — ORPHEUS derivation modules keep whole
+  `.. math:: :label:` derivations in module prose, invisible to the graph.
+- **Equation labels defined in docstrings.** Sphinx only learns labels
+  from pages it renders; the AST scanner now emits equation nodes for
+  `.. math:: :label:` definitions in any docstring, so `:eq:` references
+  to un-rendered derivations resolve.
 - **Project-rooted names misclassified as `external`.** Both phantom
   classifiers checked installed packages before project membership, and the
   analyzed project is usually pip-installed in its own build venv — 333

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to sphinxcontrib-nexus.
 
 ## Unreleased
 
+### Dead-reference detection — the silent doc-drift gate
+
+A deleted or renamed symbol leaves its doc references behind, and Sphinx
+renders them as plain text with **no warning at any severity**. Measured on
+ORPHEUS: 212 project-rooted referenced phantoms, of which 36 named genuinely
+missing code. The graph already contained the signal (reference edges whose
+target reconciled to nothing); this release makes it precise enough to gate
+on and surfaces it (MCP tools 39 → 40).
+
+### Added
+
+- **`dead_references` MCP tool + `GraphQuery.dead_references()`** — every
+  doc/docstring/type-annotation reference whose project-rooted target no
+  longer exists, with all referencing sites (file/line or docname).
+  Decidability follows the ORPHEUS `check_docstring_xrefs` discipline: only
+  project-rooted names are judged; external references are never reported.
+  Three rescue passes guard precision: exact-name match, re-export chase,
+  and an INHERITS walk (a member found on any ancestor is live; a class
+  with an un-analyzed base is *undecidable*, never dead). Dead `:eq:`
+  labels are audited too; `:math:` roles are ignored as presentation.
+- **`staleness` now carries a dead-reference summary** (top 10 +
+  total) alongside timestamp drift — dead references are the harder
+  failure of the two, and they work without git or project_root.
+- **Attribute and module-constant nodes.** The AST walker now emits
+  `ATTRIBUTE` nodes for class-level `x: T = ...` / `x = ...` and
+  `self.x = ...` bindings, and `DATA` nodes for module-level assignments —
+  previously live `:attr:`/`:data:` references were indistinguishable from
+  references to deleted code (176 of ORPHEUS's 212 referenced phantoms were
+  this and the two fixes below).
+- **Re-export alias map.** Module-scope `from X import Y` aliases are
+  recorded (`graph.metadata["reexports"]`) and chased during phantom
+  canonicalization and query-time rescue — `pkg.api.Thing` now folds onto
+  `pkg.core.thing.Thing` even when the module paths don't overlap, which
+  the leaf-name fold could never prove.
+
+### Fixed
+
+- **Project-rooted names misclassified as `external`.** Both phantom
+  classifiers checked installed packages before project membership, and the
+  analyzed project is usually pip-installed in its own build venv — 333
+  `orpheus.*` nodes sat in the external bucket, hidden from any gate.
+  Module-typed graph nodes now define project membership and win.
+- **Docstring role targets that wrap across lines** (`:class:`pkg.\n
+  Thing``) parsed to phantom names containing newlines; both the
+  `title <target>` form and plain dotted targets now normalize wrap
+  whitespace, and un-parseable role bodies are skipped instead of forging
+  unresolvable nodes.
+
 ## 0.15.0 — 2026-06-17
 
 ### Runtime overlay — dynamic execution-flow on the static graph (issue #26)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Nexus works with any Python project:
 | `derives` | Derivation → equation | AST |
 | `discriminates_on` | Function → tag it branches on (`if x == "..."`, `match`) | AST |
 
-## MCP Tools (39)
+## MCP Tools (40)
 
 ### Exploration
 - **`query`** — keyword search across node names
@@ -155,7 +155,8 @@ The static graph is *what can run*; a runtime overlay is *what actually ran*. Ca
 - **`verification_coverage`** — equation → code → test coverage map (supports `limit`/`offset` pagination)
 - **`verification_audit`** — complete V&V audit: coverage + staleness + prioritized gap list (supports `group_by` and `include_tests`)
 - **`verification_gaps`** — untagged tests, unverified equations, missing err catchers (supports `module` and `level` filters)
-- **`staleness`** — detect docs that drifted from code
+- **`staleness`** — detect docs that drifted from code: git-timestamp drift plus a dead-reference summary
+- **`dead_references`** — doc/docstring references whose code target no longer exists (deleted/renamed symbols still referenced by theory pages, docstrings, or quoted type annotations — Sphinx renders these as plain text with no warning); project-rooted names only, with re-export and inheritance rescue passes to keep false positives out
 - **`session_briefing`** — AI agent context restoration
 - **`trace_error`** — trace from failing test to equations on call path
 - **`migration_plan`** — plan dependency migration with phased blast radius

--- a/sphinxcontrib/nexus/__init__.py
+++ b/sphinxcontrib/nexus/__init__.py
@@ -38,6 +38,7 @@ def _on_env_check_consistency(app: Sphinx, env: BuildEnvironment) -> None:
 
 def _finalize_graph(graph: Any) -> None:
     """Final cleanup before export: confidence scores, phantom nodes."""
+    from sphinxcontrib.nexus.ast_analyzer import _project_module_tops
     from sphinxcontrib.nexus.extractors import _EXTERNAL_NAMES
     from sphinxcontrib.nexus.graph import NodeType
 
@@ -47,7 +48,25 @@ def _finalize_graph(graph: Any) -> None:
         if "confidence" not in data:
             data["confidence"] = 1.0
 
-    # Classify phantom nodes (created by add_edge to nonexistent targets)
+    # Classify phantom nodes (created by add_edge to nonexistent
+    # targets). Project-rooted names are never ``external``: the
+    # project is usually pip-installed in its own build venv, so the
+    # environment check alone would hide the project's own dangling
+    # references in the external bucket.
+    project_tops = _project_module_tops(g)
+
+    # Reclassify nodes an earlier pass already typed ``external`` but
+    # whose top-level module is this project's: the Sphinx extractor
+    # only knows the DOCUMENTED module set, which under-covers the
+    # project when top packages aren't automodule'd, and its
+    # installed-packages fallback then wins incorrectly.
+    for _, attrs in g.nodes(data=True):
+        if attrs.get("type") != NodeType.EXTERNAL.value:
+            continue
+        top_level = (attrs.get("name") or "").split(".")[0]
+        if top_level in project_tops:
+            attrs["type"] = NodeType.UNRESOLVED.value
+
     for node_id in list(g.nodes):
         attrs = g.nodes[node_id]
         if attrs.get("type") and attrs["type"] not in ("", "unknown"):
@@ -55,7 +74,10 @@ def _finalize_graph(graph: Any) -> None:
         parts = node_id.split(":", 2)
         name = parts[2] if len(parts) == 3 else node_id
         top_level = name.split(".")[0]
-        attrs["type"] = NodeType.EXTERNAL.value if top_level in _EXTERNAL_NAMES else NodeType.UNRESOLVED.value
+        if top_level in project_tops or top_level not in _EXTERNAL_NAMES:
+            attrs["type"] = NodeType.UNRESOLVED.value
+        else:
+            attrs["type"] = NodeType.EXTERNAL.value
         if "name" not in attrs or not attrs["name"]:
             attrs["name"] = name
             attrs["display_name"] = name

--- a/sphinxcontrib/nexus/ast_analyzer.py
+++ b/sphinxcontrib/nexus/ast_analyzer.py
@@ -74,6 +74,15 @@ def _is_dotted_identifier(name: str) -> bool:
     return bool(name) and all(part.isidentifier() for part in name.split("."))
 
 
+#: ``:label: <name>`` option line of a ``.. math::`` directive embedded
+#: in a docstring. Sphinx only learns equation labels from pages it
+#: RENDERS — a label defined in a never-automodule'd docstring is
+#: invisible to it, and every ``:eq:`` reference to that label would
+#: look dead. The AST layer reads all docstrings, so it extracts the
+#: definitions too.
+_MATH_LABEL_RE = re.compile(r"^\s*:label:\s*(\S+)\s*$", re.MULTILINE)
+
+
 def _parse_role_target(raw: str) -> str | None:
     """Extract the resolvable target from a role-body string.
 
@@ -790,6 +799,27 @@ class CodeVisitor(ast.NodeVisitor):
         docstring = ast.get_docstring(node)
         if not docstring:
             return
+
+        # Equation labels DEFINED in this docstring (``.. math::``
+        # with ``:label:``). Emitted as concrete equation nodes so
+        # ``:eq:`` references to them resolve regardless of whether
+        # Sphinx ever renders the docstring.
+        for label_match in _MATH_LABEL_RE.finditer(docstring):
+            label = label_match.group(1)
+            eq_id = f"math:equation:{label}"
+            self.nodes.append(GraphNode(
+                id=eq_id,
+                type=NodeType.EQUATION,
+                name=label,
+                display_name=label,
+                domain="math",
+                metadata={"file_path": self._file_path, "source": "ast"},
+            ))
+            self.edges.append(GraphEdge(
+                source=source_id, target=eq_id, type=EdgeType.CONTAINS,
+                metadata={"source": "ast"},
+            ))
+
         # Python-domain role → objtype
         py_type_map = {
             "func": "function", "meth": "method", "class": "class",

--- a/sphinxcontrib/nexus/ast_analyzer.py
+++ b/sphinxcontrib/nexus/ast_analyzer.py
@@ -777,6 +777,13 @@ class CodeVisitor(ast.NodeVisitor):
         their own markers (module < class < function).
         """
         self._module_pytest_meta = _collect_pytestmark_assignments(node.body)
+        # The module docstring carries references and equation-label
+        # definitions like any other docstring — ORPHEUS derivation
+        # modules keep the entire ``.. math:: :label:`` derivation in
+        # module-level prose.
+        self._add_docstring_refs(
+            node, self._node_id("module", self._module_name),
+        )
         for child in node.body:
             self.visit(child)
 

--- a/sphinxcontrib/nexus/ast_analyzer.py
+++ b/sphinxcontrib/nexus/ast_analyzer.py
@@ -13,7 +13,7 @@ import logging
 import re
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from sphinxcontrib.nexus.fingerprint import body_fingerprint
 from sphinxcontrib.nexus.graph import (
@@ -37,8 +37,41 @@ _SPHINX_ROLE_RE = re.compile(r":(\w+):`([^`]+)`")
 # declare a display title distinct from the target, like
 # ``:func:`display name <pkg.mod.actual>```. The target inside the
 # angle brackets is what we want for graph resolution; the title is
-# presentation noise.
-_ROLE_TITLE_TARGET_RE = re.compile(r"^.*?<(?P<target>[^>]+)>\s*$")
+# presentation noise. DOTALL because a docstring role body wraps
+# across lines (``:meth:`Foo.bar\n    <pkg.mod.Foo.bar>```) and the
+# title part must still match up to the ``<``.
+_ROLE_TITLE_TARGET_RE = re.compile(r"^.*?<(?P<target>[^>]+)>\s*$", re.DOTALL)
+
+# Shape of a plausible dotted reference target after line-wrap
+# whitespace is removed: dotted identifiers, plus ``-`` for equation
+# labels. Used to decide whether whitespace inside a role body is
+# docstring wrapping (collapse it) or meaningful content like inline
+# LaTeX (leave it alone).
+_DOTTED_TARGET_RE = re.compile(r"[A-Za-z_][\w.-]*")
+
+
+def _normalize_wrapped_target(candidate: str) -> str:
+    """Collapse line-wrap whitespace inside a dotted role target.
+
+    A long ``:class:`pkg.mod.Thing``` reference wraps across docstring
+    lines, leaving a newline + indent in the middle of the dotted path.
+    Sphinx normalizes that whitespace away when it resolves the role;
+    without the same normalization the graph forges a phantom whose
+    name contains a newline — unresolvable by definition. Collapse is
+    attempted only when the de-whitespaced text looks like a dotted
+    name, so ``:math:`x + y``` bodies pass through untouched.
+    """
+    if not any(ch.isspace() for ch in candidate):
+        return candidate
+    collapsed = re.sub(r"\s+", "", candidate)
+    if _DOTTED_TARGET_RE.fullmatch(collapsed.lstrip(".")):
+        return collapsed
+    return candidate
+
+
+def _is_dotted_identifier(name: str) -> bool:
+    """True when ``name`` is a well-formed dotted Python path."""
+    return bool(name) and all(part.isidentifier() for part in name.split("."))
 
 
 def _parse_role_target(raw: str) -> str | None:
@@ -76,12 +109,20 @@ def _parse_role_target(raw: str) -> str | None:
         # The inner target can still carry a ``~`` hint.
         if inner.startswith("~"):
             inner = inner[1:]
+        # A leading ``.`` marks a Sphinx relative/suffix-match target
+        # (``:meth:`.Quadrature.product```); the dots themselves are
+        # display syntax, not part of the dotted path.
+        inner = _normalize_wrapped_target(inner).lstrip(".")
         return inner or None
 
     # Plain target, possibly with a leading ``~`` display hint.
     if stripped.startswith("~"):
-        return stripped[1:] or None
-    return stripped
+        stripped = stripped[1:]
+    stripped = _normalize_wrapped_target(stripped)
+    # Same relative-target convention as the title form above.
+    if stripped.startswith(".") and _DOTTED_TARGET_RE.fullmatch(stripped.lstrip(".")):
+        stripped = stripped.lstrip(".")
+    return stripped or None
 
 
 # ---------------------------------------------------------------------------
@@ -601,6 +642,39 @@ def _discriminated_tags(
 # ---------------------------------------------------------------------------
 
 
+def _iter_name_targets(target: ast.expr) -> Iterator[str]:
+    """Yield plain names bound by an assignment target.
+
+    Handles ``x = ...``, ``x, y = ...`` and ``[x, y] = ...``. Attribute
+    and subscript targets are someone else's binding, not a new name in
+    this scope.
+    """
+    if isinstance(target, ast.Name):
+        yield target.id
+    elif isinstance(target, (ast.Tuple, ast.List)):
+        for elt in target.elts:
+            if isinstance(elt, ast.Name):
+                yield elt.id
+
+
+def _iter_self_attr_names(stmt: ast.Assign | ast.AnnAssign) -> Iterator[str]:
+    """Yield attribute names bound on ``self`` by an assignment.
+
+    Covers ``self.x = ...``, ``self.x: T = ...`` and tuple unpacking
+    ``self.a, self.b = ...``.
+    """
+    targets = stmt.targets if isinstance(stmt, ast.Assign) else [stmt.target]
+    for tgt in targets:
+        elts = tgt.elts if isinstance(tgt, (ast.Tuple, ast.List)) else [tgt]
+        for elt in elts:
+            if (
+                isinstance(elt, ast.Attribute)
+                and isinstance(elt.value, ast.Name)
+                and elt.value.id == "self"
+            ):
+                yield elt.attr
+
+
 class CodeVisitor(ast.NodeVisitor):
     """Walk a Python file's AST and extract nodes and edges."""
 
@@ -625,6 +699,21 @@ class CodeVisitor(ast.NodeVisitor):
         # Synthetic tag nodes are shared across the functions that
         # discriminate on them; emit each at most once per file.
         self._tags_emitted: set[str] = set()
+        # Attribute/data binding nodes already emitted, keyed by node
+        # id — a class-level annotation and a ``self.x = ...`` in
+        # ``__init__`` describe the same attribute once.
+        self._bindings_emitted: set[str] = set()
+        # Depth of the class-scope stack. Assignment visitors use it to
+        # tell module-level bindings (DATA) from class-level ones
+        # (ATTRIBUTE). Function bodies are never visited statement-wise
+        # (only ``ast.walk``-ed for calls), so these visitors cannot
+        # fire at function scope.
+        self._class_depth = 0
+        # Module-scope ``from X import Y`` aliases: public dotted path
+        # → defining dotted path. ``analyze_directory`` aggregates
+        # these into graph metadata so phantom canonicalization can
+        # chase re-export chains.
+        self.reexports: dict[str, str] = {}
 
         # Create module node
         self.nodes.append(GraphNode(
@@ -703,6 +792,11 @@ class CodeVisitor(ast.NodeVisitor):
                 target_id = f"math:equation:{target}"
             elif role in py_type_map:
                 resolved = self._imports.resolve(target)
+                if not _is_dotted_identifier(resolved):
+                    # Not a well-formed dotted path even after
+                    # wrap-normalization — forging a node for it
+                    # would create a phantom nothing can resolve.
+                    continue
                 target_id = f"py:{py_type_map[role]}:{resolved}"
             else:
                 # Unknown or unsupported role — skip rather than forge a
@@ -744,6 +838,122 @@ class CodeVisitor(ast.NodeVisitor):
                 type=EdgeType.IMPORTS,
                 metadata={"full_import": node.module, "source": "ast"},
             ))
+        # Record module-scope aliases as re-export candidates:
+        # ``from .mesh import Thing`` in ``pkg/__init__.py`` makes
+        # ``pkg.Thing`` a live public path for ``pkg.mesh.Thing``.
+        # ImportTracker has just registered the alias, so resolving
+        # the local name yields the defining dotted path.
+        if self._class_depth == 0 and node.module != "__future__":
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                local = alias.asname or alias.name
+                qualified = self._imports.resolve(local)
+                public = f"{self._module_name}.{local}"
+                if qualified != local and qualified != public:
+                    self.reexports[public] = qualified
+
+    def _emit_binding(
+        self,
+        name: str,
+        lineno: int,
+        annotation: str | None = None,
+    ) -> None:
+        """Emit an ATTRIBUTE (class scope) or DATA (module scope) node.
+
+        These bindings are what ``:attr:`` / ``:data:`` doc references
+        point at; without them every live reference to an annotated
+        attribute or module constant is indistinguishable from a
+        reference to deleted code.
+        """
+        if name == "_":
+            return
+        owner = self._qualified_name
+        if self._class_depth > 0:
+            type_str = "attribute"
+            node_type = NodeType.ATTRIBUTE
+            parent_id = self._node_id("class", owner)
+        else:
+            type_str = "data"
+            node_type = NodeType.DATA
+            parent_id = self._node_id("module", owner)
+        qname = f"{owner}.{name}"
+        binding_id = self._node_id(type_str, qname)
+        if binding_id in self._bindings_emitted:
+            return
+        self._bindings_emitted.add(binding_id)
+
+        meta: dict[str, object] = {
+            "file_path": self._file_path,
+            "lineno": lineno,
+            "source": "ast",
+        }
+        if self._is_test_file:
+            meta["is_test"] = True
+        if annotation:
+            meta["annotation"] = annotation
+        self.nodes.append(GraphNode(
+            id=binding_id,
+            type=node_type,
+            name=qname,
+            display_name=name,
+            domain="py",
+            metadata=meta,
+        ))
+        self.edges.append(GraphEdge(
+            source=parent_id, target=binding_id, type=EdgeType.CONTAINS,
+            metadata={"source": "ast"},
+        ))
+
+    def _emit_instance_attribute(
+        self, cls_qname: str, name: str, lineno: int,
+    ) -> None:
+        """Emit an ATTRIBUTE node for a ``self.<name>`` binding.
+
+        Same node namespace as class-level bindings, so an annotated
+        declaration and the ``__init__`` assignment collapse into one
+        node.
+        """
+        attr_id = self._node_id("attribute", f"{cls_qname}.{name}")
+        if attr_id in self._bindings_emitted:
+            return
+        self._bindings_emitted.add(attr_id)
+        meta: dict[str, object] = {
+            "file_path": self._file_path,
+            "lineno": lineno,
+            "source": "ast",
+        }
+        if self._is_test_file:
+            meta["is_test"] = True
+        self.nodes.append(GraphNode(
+            id=attr_id,
+            type=NodeType.ATTRIBUTE,
+            name=f"{cls_qname}.{name}",
+            display_name=name,
+            domain="py",
+            metadata=meta,
+        ))
+        self.edges.append(GraphEdge(
+            source=self._node_id("class", cls_qname),
+            target=attr_id,
+            type=EdgeType.CONTAINS,
+            metadata={"source": "ast"},
+        ))
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        for tgt in node.targets:
+            for name in _iter_name_targets(tgt):
+                self._emit_binding(name, node.lineno)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if isinstance(node.target, ast.Name):
+            try:
+                annotation = ast.unparse(node.annotation)
+            except Exception:
+                annotation = None
+            self._emit_binding(
+                node.target.id, node.lineno, annotation=annotation,
+            )
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self._scope.append(node.name)
@@ -816,8 +1026,10 @@ class CodeVisitor(ast.NodeVisitor):
         # Visit only direct body statements (methods, nested classes)
         # NOT generic_visit which recurses into all descendants and can
         # blow the stack on files with deeply nested expressions.
+        self._class_depth += 1
         for child in node.body:
             self.visit(child)
+        self._class_depth -= 1
         self._scope.pop()
         self._current_class_pytest_meta = prev_class_meta
 
@@ -964,7 +1176,9 @@ class CodeVisitor(ast.NodeVisitor):
 
         self._add_docstring_refs(node, func_id)
 
-        # Walk body for CALLS edges
+        # Walk body for CALLS edges and, in methods, instance
+        # attributes bound on ``self``.
+        cls_qname = ".".join(self._scope[:-1]) if is_method else None
         for child in ast.walk(node):
             if isinstance(child, ast.Call):
                 target = _resolve_call_target(child, self._imports)
@@ -987,6 +1201,14 @@ class CodeVisitor(ast.NodeVisitor):
                             "source": "ast",
                         },
                     ))
+            elif cls_qname and isinstance(child, (ast.Assign, ast.AnnAssign)):
+                # ``self.x = ...`` declares an instance attribute of
+                # the enclosing class — the target of ``:attr:`` doc
+                # references, so it must exist as a graph node.
+                for attr_name in _iter_self_attr_names(child):
+                    self._emit_instance_attribute(
+                        cls_qname, attr_name, child.lineno,
+                    )
 
         # Don't call generic_visit — we already walked the body for Call nodes
         self._scope.pop()
@@ -1058,6 +1280,11 @@ def analyze_directory(
 
     resolver = ModuleResolver(project_root, sys_path_dirs)
     graph = KnowledgeGraph()
+    # Public dotted path → defining dotted path, from module-scope
+    # ``from X import Y`` statements. Persisted in graph metadata so
+    # both the in-pipeline canonicalization passes and query-time
+    # consumers can chase re-export chains.
+    reexports: dict[str, str] = {}
 
     # Pre-compute exclusion directory names for fast filtering
     _skip_dirs = {".venv", "venv", "__pycache__", "node_modules", ".tox", ".git"}
@@ -1095,6 +1322,9 @@ def analyze_directory(
             graph.add_node(node)
         for edge in visitor.edges:
             graph.add_edge(edge)
+        reexports.update(visitor.reexports)
+
+    graph.metadata["reexports"] = reexports
 
     # Classify phantom nodes created by add_edge for targets not in the graph.
     # These are external functions/modules (numpy.array, scipy.integrate.quad, etc.)
@@ -1126,6 +1356,8 @@ _CANONICAL_TYPES: frozenset[str] = frozenset({
     NodeType.MODULE.value,
     NodeType.EXCEPTION.value,
     NodeType.TYPE.value,
+    NodeType.ATTRIBUTE.value,
+    NodeType.DATA.value,
 })
 
 #: Node types that MAY be folded into a canonical by
@@ -1266,6 +1498,33 @@ def _module_paths_overlap(phantom_name: str, canonical_name: str) -> bool:
     return False
 
 
+def _chase_reexports(name: str, reexports: dict[str, str]) -> str:
+    """Resolve ``name`` through re-export aliases to its defining path.
+
+    Follows chains (``pkg.Thing`` → ``pkg.geometry.Thing`` →
+    ``pkg.geometry.mesh.Thing``) and rewrites dotted prefixes, so
+    ``pkg.Thing.method`` resolves through the ``pkg.Thing`` alias too.
+    A seen-set guards against alias cycles.
+    """
+    seen: set[str] = set()
+    current = name
+    while current not in seen:
+        seen.add(current)
+        if current in reexports:
+            current = reexports[current]
+            continue
+        # Longest dotted prefix that is itself an alias.
+        parts = current.split(".")
+        for cut in range(len(parts) - 1, 0, -1):
+            prefix = ".".join(parts[:cut])
+            if prefix in reexports:
+                current = ".".join([reexports[prefix], *parts[cut:]])
+                break
+        else:
+            break
+    return current
+
+
 def _canonical_rank_key(
     cid: str, cname: str, attrs: dict,
 ) -> tuple[int, int, str]:
@@ -1337,8 +1596,10 @@ def _canonicalize_phantoms(graph: KnowledgeGraph) -> int:
     # canonical by definition, even if the type attr is stale.
     _upgrade_types_from_signals(graph)
 
-    # Build leaf-name → list of (canonical_id, canonical_name) pairs.
+    # Build leaf-name → and full-name → (canonical_id, canonical_name)
+    # indexes over the concrete nodes phantoms may fold into.
     leaf_index: dict[str, list[tuple[str, str]]] = {}
+    name_index: dict[str, list[tuple[str, str]]] = {}
     for nid, attrs in g.nodes(data=True):
         if attrs.get("type") not in _CANONICAL_TYPES:
             continue
@@ -1347,6 +1608,9 @@ def _canonicalize_phantoms(graph: KnowledgeGraph) -> int:
             continue
         leaf = name.rsplit(".", 1)[-1]
         leaf_index.setdefault(leaf, []).append((nid, name))
+        name_index.setdefault(name, []).append((nid, name))
+
+    reexports: dict[str, str] = graph.metadata.get("reexports") or {}
 
     removed = 0
     for nid in list(g.nodes):
@@ -1358,25 +1622,40 @@ def _canonicalize_phantoms(graph: KnowledgeGraph) -> int:
         if not name:
             continue
 
-        leaf = name.rsplit(".", 1)[-1]
-        all_candidates = [
-            (cid, cname)
-            for cid, cname in leaf_index.get(leaf, [])
-            if cid != nid
-        ]
+        # Exact resolution through re-export aliases first: a phantom
+        # named by a public path (``pkg.Thing``) folds onto the node
+        # at its defining path (``pkg.geometry.mesh.Thing``) with no
+        # leaf-collision heuristics involved.
+        matched: list[tuple[str, str]] = []
+        if reexports:
+            resolved = _chase_reexports(name, reexports)
+            if resolved != name:
+                matched = [
+                    (cid, cname)
+                    for cid, cname in name_index.get(resolved, [])
+                    if cid != nid
+                ]
 
-        if "." in name:
-            # Qualified phantom — filter by module-path overlap so
-            # cross-module same-leaf collisions don't collapse.
-            matched = [
+        if not matched:
+            leaf = name.rsplit(".", 1)[-1]
+            all_candidates = [
                 (cid, cname)
-                for cid, cname in all_candidates
-                if _module_paths_overlap(name, cname)
+                for cid, cname in leaf_index.get(leaf, [])
+                if cid != nid
             ]
-        else:
-            # Bare-name phantom — the phantom has no module path, so
-            # fall back to "unique leaf match across the whole graph".
-            matched = list(all_candidates)
+
+            if "." in name:
+                # Qualified phantom — filter by module-path overlap so
+                # cross-module same-leaf collisions don't collapse.
+                matched = [
+                    (cid, cname)
+                    for cid, cname in all_candidates
+                    if _module_paths_overlap(name, cname)
+                ]
+            else:
+                # Bare-name phantom — the phantom has no module path, so
+                # fall back to "unique leaf match across the whole graph".
+                matched = list(all_candidates)
 
         if not matched:
             continue
@@ -1415,16 +1694,38 @@ def _canonicalize_phantoms(graph: KnowledgeGraph) -> int:
     return removed
 
 
+def _project_module_tops(g: "Any") -> set[str]:
+    """Top-level segments of every module node in the graph.
+
+    Module-typed nodes only exist for modules the AST layer analyzed
+    or Sphinx documented — never for phantoms — so this is the set of
+    names that belong to THIS project. It must be consulted before any
+    installed-packages check: the project itself is usually pip-
+    installed in its own build environment (editable install), so an
+    environment lookup alone classifies the project's own dangling
+    references as ``external`` and hides them from staleness gating.
+    """
+    tops = {
+        (attrs.get("name") or "").split(".")[0]
+        for _, attrs in g.nodes(data=True)
+        if attrs.get("type") == NodeType.MODULE.value
+    }
+    tops.discard("")
+    return tops
+
+
 def _classify_phantom_nodes(graph: KnowledgeGraph) -> None:
     """Add type/name attributes to nodes auto-created by NetworkX.
 
     When add_edge references a node that doesn't exist, NetworkX creates
     it with no attributes. We classify these as EXTERNAL (stdlib/packages)
-    or leave as-is for project-internal symbols.
+    or UNRESOLVED for project-internal symbols. Project-rooted names win
+    over the environment check — see ``_project_module_tops``.
     """
     from sphinxcontrib.nexus.extractors import _EXTERNAL_NAMES
 
     g = graph.nxgraph
+    project_tops = _project_module_tops(g)
     for node_id in list(g.nodes):
         attrs = g.nodes[node_id]
         if attrs.get("type") and attrs["type"] not in ("", "unknown"):
@@ -1435,7 +1736,9 @@ def _classify_phantom_nodes(graph: KnowledgeGraph) -> None:
         name = parts[2] if len(parts) == 3 else node_id
         top_level = name.split(".")[0]
 
-        if top_level in _EXTERNAL_NAMES:
+        if top_level in project_tops:
+            node_type = NodeType.UNRESOLVED.value
+        elif top_level in _EXTERNAL_NAMES:
             node_type = NodeType.EXTERNAL.value
         else:
             node_type = NodeType.UNRESOLVED.value

--- a/sphinxcontrib/nexus/ast_analyzer.py
+++ b/sphinxcontrib/nexus/ast_analyzer.py
@@ -384,14 +384,33 @@ class ImportTracker:
         from . import foo           → foo → <parent_module>.foo
     """
 
-    def __init__(self, module_name: str) -> None:
+    def __init__(self, module_name: str, is_package: bool = False) -> None:
         self._module_name = module_name
+        self._is_package = is_package
         self._aliases: dict[str, str] = {}
         self._has_future_annotations = False
 
     @property
     def has_future_annotations(self) -> bool:
         return self._has_future_annotations
+
+    def relative_anchor(self, level: int) -> str:
+        """The package a ``level``-dot relative import resolves against.
+
+        One dot means the CURRENT package: the module itself when it is
+        a package (``__init__.py``), its parent otherwise — getting this
+        wrong drops a path segment from every symbol imported relatively
+        inside a nested package's ``__init__.py``. Each additional dot
+        climbs one parent. Clamps at the top level rather than raising
+        on a malformed over-deep import.
+        """
+        anchor = self._module_name
+        climbs = level - 1 if self._is_package else level
+        for _ in range(climbs):
+            if "." not in anchor:
+                break
+            anchor = anchor.rsplit(".", 1)[0]
+        return anchor
 
     def add_import(self, node: ast.Import) -> None:
         for alias in node.names:
@@ -407,8 +426,7 @@ class ImportTracker:
             return
         # Handle relative imports
         if node.level > 0:
-            parts = self._module_name.rsplit(".", node.level)
-            base = parts[0] if parts else ""
+            base = self.relative_anchor(node.level)
             module = f"{base}.{module}" if module else base
         for alias in node.names:
             local_name = alias.asname or alias.name
@@ -688,7 +706,10 @@ class CodeVisitor(ast.NodeVisitor):
         self._file_path = file_path
         self._is_test_file = is_test_file
         self._scope: list[str] = [module_name]
-        self._imports = ImportTracker(module_name)
+        self._imports = ImportTracker(
+            module_name,
+            is_package=file_path.endswith("__init__.py"),
+        )
         self.nodes: list[GraphNode] = []
         self.edges: list[GraphEdge] = []
         # Pytest-marker metadata stashed at module and class scope.
@@ -829,8 +850,7 @@ class CodeVisitor(ast.NodeVisitor):
             target_module = node.module.split(".")[0]
             # Resolve relative imports
             if node.level > 0:
-                parts = self._module_name.rsplit(".", node.level)
-                base = parts[0] if parts else ""
+                base = self._imports.relative_anchor(node.level)
                 target_module = base.split(".")[0] if base else target_module
             self.edges.append(GraphEdge(
                 source=module_id,
@@ -1009,6 +1029,12 @@ class CodeVisitor(ast.NodeVisitor):
 
         # INHERITS from base classes
         for base in node.bases:
+            # A generic base ``Composite[Bulk, Boundary]`` inherits
+            # from ``Composite`` — dropping Subscript bases severed
+            # the INHERITS chain for every Generic-parameterized
+            # class, which broke inherited-member resolution.
+            if isinstance(base, ast.Subscript):
+                base = base.value
             if isinstance(base, ast.Name):
                 base_name = self._imports.resolve(base.id)
             elif isinstance(base, ast.Attribute):

--- a/sphinxcontrib/nexus/merge.py
+++ b/sphinxcontrib/nexus/merge.py
@@ -56,6 +56,13 @@ def merge_graphs(
     sg = sphinx_kg.nxgraph
     ag = ast_kg.nxgraph
 
+    # Carry the AST layer's re-export alias map over so the post-merge
+    # canonicalization pass (and query-time consumers of the exported
+    # metadata) can chase public-path references to defining paths.
+    ast_reexports = ast_kg.metadata.get("reexports") or {}
+    if ast_reexports:
+        sphinx_kg.metadata.setdefault("reexports", {}).update(ast_reexports)
+
     # Step 1 & 2: merge nodes
     for node_id, ast_attrs in ag.nodes(data=True):
         if node_id in sg:

--- a/sphinxcontrib/nexus/query.py
+++ b/sphinxcontrib/nexus/query.py
@@ -412,12 +412,52 @@ class StalenessEntry:
 
 
 @dataclass
+class DeadReferenceSite:
+    """One place that still references a vanished target."""
+
+    source: NodeResult
+    edge_type: str
+    reftype: str = ""
+
+
+@dataclass
+class DeadReference:
+    """A referenced code symbol or equation label that no longer exists.
+
+    The silent-drift shape: the target was deleted or renamed, the
+    references outlived it, and Sphinx renders them as plain text
+    without any warning.
+    """
+
+    target_id: str
+    target_name: str
+    kind: str  # "python" | "equation"
+    site_count: int
+    sites: list[DeadReferenceSite]
+
+
+@dataclass
+class DeadReferencesResult:
+    """Dead-reference audit over the whole graph."""
+
+    dead: list[DeadReference]
+    total_dead: int
+    total_sites: int
+    total_checked: int
+    rescued: int
+    undecidable: int
+    project_modules: list[str]
+
+
+@dataclass
 class StalenessResult:
     """Doc-code drift analysis."""
 
     stale_docs: list[StalenessEntry]
     total_stale: int
     total_checked: int
+    dead_references: list[DeadReference] = field(default_factory=list)
+    total_dead_references: int = 0
 
 
 @dataclass
@@ -1784,14 +1824,26 @@ class GraphQuery:
     ) -> StalenessResult:
         """Detect documentation pages that drifted from code.
 
-        Compares git modification timestamps of doc files vs. the code
-        files they reference.
+        Two independent drift signals:
+
+        * timestamp drift — git says the code a page references was
+          modified after the page (needs ``project_root`` + git);
+        * dead references — prose still references symbols/equations
+          that no longer exist (see :meth:`dead_references`; works on
+          the graph alone). The harder failure of the two: Sphinx
+          renders a dead reference as plain text with no warning.
         """
+        dead = self.dead_references()
+
         stale: list[StalenessEntry] = []
         checked = 0
 
         if project_root is None:
-            return StalenessResult(stale_docs=[], total_stale=0, total_checked=0)
+            return StalenessResult(
+                stale_docs=[], total_stale=0, total_checked=0,
+                dead_references=dead.dead[:10],
+                total_dead_references=dead.total_dead,
+            )
 
         project_root = Path(project_root)
         timestamps = self._git_file_timestamps(project_root)
@@ -1846,7 +1898,202 @@ class GraphQuery:
             stale_docs=stale,
             total_stale=len(stale),
             total_checked=checked,
+            dead_references=dead.dead[:10],
+            total_dead_references=dead.total_dead,
         )
+
+    #: Reference-carrying edge types eligible for the dead-reference
+    #: audit. CALLS is deliberately absent: call-target resolution is
+    #: heuristic (attribute calls, dynamic dispatch), so a phantom
+    #: call target is weak evidence that the callee was deleted.
+    _DEAD_REF_EDGE_TYPES = frozenset(
+        {"references", "documents", "type_uses", "equation_ref"}
+    )
+
+    #: Node types that mean "no concrete definition found".
+    _PHANTOM_NODE_TYPES = frozenset({"unresolved", "external", ""})
+
+    def dead_references(
+        self, max_sites_per_target: int = 25,
+    ) -> DeadReferencesResult:
+        """Doc/docstring references whose target no longer exists.
+
+        The drift shape this catches: a class, function, attribute, or
+        equation label was deleted or renamed, but prose — a theory
+        page, another docstring, a quoted type annotation — still
+        references the old name. Sphinx renders such references as
+        plain text and emits no warning, so nothing else surfaces them.
+
+        Detection is static and graph-native. After merge and phantom
+        canonicalization, a reference-carrying edge whose target is
+        still a phantom node rooted in a PROJECT module names a symbol
+        that neither the Sphinx domain nor the AST walker could find
+        anywhere in the analyzed tree. References rooted outside the
+        project (numpy, stdlib) are not decidable from this graph and
+        are never reported. Three rescue passes keep precision high:
+
+        * exact-name match against any concrete node (a property
+          referenced as ``:attr:`` resolves to its method node);
+        * re-export chase through the ``reexports`` metadata map
+          (``pkg.Thing`` is live when ``pkg/__init__.py`` re-exports
+          ``pkg.mesh.Thing``);
+        * inheritance walk — ``Sub.attr`` is live when any ancestor
+          class defines ``attr``; a class with an un-analyzed
+          (external/unresolved) base is UNDECIDABLE, not dead.
+
+        Equation references are audited from ``:eq:`` roles and
+        ``equation_ref`` edges only — ``:math:`` roles are inline
+        presentation, not label references. Sphinx sees every equation
+        label in the doc set, so a phantom equation target has no
+        blind spot.
+
+        Known static-analysis limits (same as any import-free
+        checker): symbols created dynamically (``__getattr__``,
+        metaclass magic) can be reported dead despite resolving at
+        runtime.
+        """
+        g = self._g
+
+        project_tops = {
+            (attrs.get("name") or "").split(".")[0]
+            for _, attrs in g.nodes(data=True)
+            if attrs.get("type") == "module"
+        }
+        project_tops.discard("")
+
+        reexports: dict[str, str] = self._kg.metadata.get("reexports") or {}
+
+        # Every dotted name that has a concrete (non-phantom) node.
+        concrete_names: set[str] = set()
+        for _, attrs in g.nodes(data=True):
+            if attrs.get("type", "") not in self._PHANTOM_NODE_TYPES:
+                name = attrs.get("name")
+                if name:
+                    concrete_names.add(name)
+
+        # Candidate targets: phantom nodes referenced by eligible edges.
+        sites_by_target: dict[str, list[DeadReferenceSite]] = {}
+        kinds: dict[str, str] = {}
+        for src, tgt, data in g.edges(data=True):
+            edge_type = str(data.get("type", ""))
+            if edge_type not in self._DEAD_REF_EDGE_TYPES:
+                continue
+            tattrs = g.nodes.get(tgt)
+            if tattrs is None:
+                continue
+            if tattrs.get("type", "") not in self._PHANTOM_NODE_TYPES:
+                continue
+            if tattrs.get("domain") == "citation":
+                continue  # citation nodes are phantom by design
+            reftype = str(data.get("reftype", ""))
+            if tgt.startswith("math:equation:"):
+                if edge_type != "equation_ref" and reftype != "eq":
+                    continue
+                kinds[tgt] = "equation"
+            elif tgt.startswith("py:"):
+                name = tattrs.get("name") or ""
+                if name.split(".")[0] not in project_tops:
+                    continue
+                kinds[tgt] = "python"
+            else:
+                continue
+            sites_by_target.setdefault(tgt, []).append(DeadReferenceSite(
+                source=self._node_result(src),
+                edge_type=edge_type,
+                reftype=reftype,
+            ))
+
+        dead: list[DeadReference] = []
+        rescued = undecidable = 0
+        for tgt, sites in sites_by_target.items():
+            tattrs = g.nodes.get(tgt, {})
+            name = tattrs.get("name") or tgt.split(":", 2)[-1]
+            if kinds[tgt] == "python":
+                verdict = self._dead_ref_verdict(
+                    name, concrete_names, reexports,
+                )
+                if verdict == "live":
+                    rescued += 1
+                    continue
+                if verdict == "undecidable":
+                    undecidable += 1
+                    continue
+            dead.append(DeadReference(
+                target_id=tgt,
+                target_name=name,
+                kind=kinds[tgt],
+                site_count=len(sites),
+                sites=sites[:max_sites_per_target],
+            ))
+
+        dead.sort(key=lambda d: (-d.site_count, d.target_name))
+        return DeadReferencesResult(
+            dead=dead,
+            total_dead=len(dead),
+            total_sites=sum(d.site_count for d in dead),
+            total_checked=len(sites_by_target),
+            rescued=rescued,
+            undecidable=undecidable,
+            project_modules=sorted(project_tops),
+        )
+
+    def _dead_ref_verdict(
+        self,
+        name: str,
+        concrete_names: set[str],
+        reexports: dict[str, str],
+    ) -> str:
+        """``"live"`` / ``"dead"`` / ``"undecidable"`` for a
+        project-rooted dotted name with no concrete node of its own."""
+        from sphinxcontrib.nexus.ast_analyzer import _chase_reexports
+
+        if name in concrete_names:
+            return "live"
+        if reexports:
+            resolved = _chase_reexports(name, reexports)
+            if resolved != name and resolved in concrete_names:
+                return "live"
+        if "." not in name:
+            return "dead"
+        # The name may be an inherited member: ``Sub.attr`` where
+        # ``attr`` is defined on an ancestor of ``Sub``.
+        class_path, leaf = name.rsplit(".", 1)
+        class_id = f"py:class:{class_path}"
+        if class_id not in self._g:
+            return "dead"
+        return self._member_on_ancestors(class_id, leaf, concrete_names)
+
+    def _member_on_ancestors(
+        self,
+        class_id: str,
+        leaf: str,
+        concrete_names: set[str],
+    ) -> str:
+        """Walk INHERITS edges looking for ``<ancestor>.<leaf>``.
+
+        Returns ``"live"`` when an ancestor defines the member,
+        ``"undecidable"`` when any ancestor is a phantom (an
+        un-analyzed base could define anything), else ``"dead"``.
+        """
+        g = self._g
+        visited = {class_id}
+        stack = [class_id]
+        saw_opaque_base = False
+        while stack:
+            current = stack.pop()
+            for _, base, data in g.out_edges(current, data=True):
+                if data.get("type") != "inherits" or base in visited:
+                    continue
+                visited.add(base)
+                battrs = g.nodes.get(base, {})
+                if battrs.get("type", "") in self._PHANTOM_NODE_TYPES:
+                    saw_opaque_base = True
+                    continue
+                bname = battrs.get("name") or base.split(":", 2)[-1]
+                if f"{bname}.{leaf}" in concrete_names:
+                    return "live"
+                stack.append(base)
+        return "undecidable" if saw_opaque_base else "dead"
 
     @staticmethod
     def _git_file_timestamps(project_root: Path) -> dict[str, str]:

--- a/sphinxcontrib/nexus/query.py
+++ b/sphinxcontrib/nexus/query.py
@@ -2058,30 +2058,45 @@ class GraphQuery:
         project-rooted dotted name with no concrete node of its own."""
         from sphinxcontrib.nexus.ast_analyzer import _chase_reexports
 
-        if name in concrete_names:
-            return "live"
+        # Judge the name both as written and through re-export
+        # aliases: a member referenced by its public path
+        # (``pkg.SourceSink.zeros_on``) may only be findable on the
+        # defining class's ancestors, so every later check must run
+        # on the chased spelling too.
+        candidates = [name]
         if reexports:
             resolved = _chase_reexports(name, reexports)
-            if resolved != name and resolved in concrete_names:
+            if resolved != name:
+                candidates.append(resolved)
+
+        saw_undecidable = False
+        for candidate in candidates:
+            if candidate in concrete_names:
                 return "live"
-        if "." not in name:
-            return "dead"
-        class_path, leaf = name.rsplit(".", 1)
-        if leaf.startswith("__") and leaf.endswith("__"):
-            # Dunder members: ``object`` provides most of them
-            # implicitly and ``pkg.mod.__init__`` names a module file
-            # — when the owner exists at all, the reference is live.
-            if (
-                class_path in concrete_names
-                or f"py:class:{class_path}" in self._g
-            ):
+            if "." not in candidate:
+                continue
+            class_path, leaf = candidate.rsplit(".", 1)
+            if leaf.startswith("__") and leaf.endswith("__"):
+                # Dunder members: ``object`` provides most of them
+                # implicitly and ``pkg.mod.__init__`` names a module
+                # file — when the owner exists at all, the reference
+                # is live.
+                if (
+                    class_path in concrete_names
+                    or f"py:class:{class_path}" in self._g
+                ):
+                    return "live"
+            # The name may be an inherited member: ``Sub.attr`` where
+            # ``attr`` is defined on an ancestor of ``Sub``.
+            class_id = f"py:class:{class_path}"
+            if class_id not in self._g:
+                continue
+            verdict = self._member_on_ancestors(class_id, leaf, concrete_names)
+            if verdict == "live":
                 return "live"
-        # The name may be an inherited member: ``Sub.attr`` where
-        # ``attr`` is defined on an ancestor of ``Sub``.
-        class_id = f"py:class:{class_path}"
-        if class_id not in self._g:
-            return "dead"
-        return self._member_on_ancestors(class_id, leaf, concrete_names)
+            if verdict == "undecidable":
+                saw_undecidable = True
+        return "undecidable" if saw_undecidable else "dead"
 
     def _member_on_ancestors(
         self,

--- a/sphinxcontrib/nexus/query.py
+++ b/sphinxcontrib/nexus/query.py
@@ -1913,6 +1913,17 @@ class GraphQuery:
     #: Node types that mean "no concrete definition found".
     _PHANTOM_NODE_TYPES = frozenset({"unresolved", "external", ""})
 
+    #: Un-analyzed base classes that are known to add no user-visible
+    #: members. Inheriting from these must NOT make member lookups
+    #: undecidable — otherwise every Generic-parameterized or ABC
+    #: subclass escapes the dead-reference gate entirely.
+    _TRANSPARENT_BASES = frozenset({
+        "object", "builtins.object",
+        "typing.Generic", "typing_extensions.Generic",
+        "typing.Protocol", "typing_extensions.Protocol",
+        "abc.ABC",
+    })
+
     def dead_references(
         self, max_sites_per_target: int = 25,
     ) -> DeadReferencesResult:
@@ -2055,9 +2066,18 @@ class GraphQuery:
                 return "live"
         if "." not in name:
             return "dead"
+        class_path, leaf = name.rsplit(".", 1)
+        if leaf.startswith("__") and leaf.endswith("__"):
+            # Dunder members: ``object`` provides most of them
+            # implicitly and ``pkg.mod.__init__`` names a module file
+            # — when the owner exists at all, the reference is live.
+            if (
+                class_path in concrete_names
+                or f"py:class:{class_path}" in self._g
+            ):
+                return "live"
         # The name may be an inherited member: ``Sub.attr`` where
         # ``attr`` is defined on an ancestor of ``Sub``.
-        class_path, leaf = name.rsplit(".", 1)
         class_id = f"py:class:{class_path}"
         if class_id not in self._g:
             return "dead"
@@ -2086,10 +2106,11 @@ class GraphQuery:
                     continue
                 visited.add(base)
                 battrs = g.nodes.get(base, {})
-                if battrs.get("type", "") in self._PHANTOM_NODE_TYPES:
-                    saw_opaque_base = True
-                    continue
                 bname = battrs.get("name") or base.split(":", 2)[-1]
+                if battrs.get("type", "") in self._PHANTOM_NODE_TYPES:
+                    if bname not in self._TRANSPARENT_BASES:
+                        saw_opaque_base = True
+                    continue
                 if f"{bname}.{leaf}" in concrete_names:
                     return "live"
                 stack.append(base)

--- a/sphinxcontrib/nexus/server.py
+++ b/sphinxcontrib/nexus/server.py
@@ -968,12 +968,39 @@ def verification_coverage(
 def staleness() -> str:
     """Detect documentation pages that drifted from code.
 
-    Compares git timestamps: if code was modified after its documentation
-    page, the doc is flagged as stale. Only works with git and project_root set.
+    Two drift signals: timestamp drift (code modified after the page that
+    documents it — needs git and project_root) and dead references (top 10;
+    the full list lives in the dead_references tool).
     """
     q = _get_query()
     result = q.staleness(_active_root())
     return to_json(to_dict(result))
+
+
+@nexus_tool
+def dead_references(limit: int = 50) -> str:
+    """Doc/docstring references whose code target no longer exists.
+
+    The silent-drift failure: a class/function/attribute/equation was
+    deleted or renamed but theory pages, docstrings, or quoted type
+    annotations still reference the old name — Sphinx renders those as
+    plain text with no warning. Reports each dead target with every
+    site that still references it (file/line for docstrings, docname
+    for pages). Only project-rooted names are judged; external
+    references and members of classes with un-analyzed bases are never
+    reported. ``rescued``/``undecidable`` counts show how many
+    candidate targets the precision passes filtered out.
+
+    Args:
+        limit: Maximum dead targets to return (most-referenced first).
+            0 means no limit. Totals always reflect the full count.
+    """
+    q = _get_query()
+    result = q.dead_references()
+    payload = to_dict(result)
+    if limit > 0:
+        payload["dead"] = payload["dead"][:limit]
+    return to_json(payload)
 
 
 def _briefing_payload() -> dict[str, Any]:

--- a/tests/test_dead_references.py
+++ b/tests/test_dead_references.py
@@ -168,6 +168,41 @@ def test_docstring_math_label_defines_equation_node(tmp_path):
     assert "gone-label" in dead_names
 
 
+def test_module_docstring_label_and_refs_are_extracted(tmp_path):
+    """Module-level docstrings were never scanned at all — a label
+    defined in module prose (the ORPHEUS derivation-module shape) made
+    every reference to it look dead."""
+    graph = _analyze_source(
+        tmp_path,
+        '"""Derivation module.\n'
+        '\n'
+        '.. math::\n'
+        '   :label: module-level-identity\n'
+        '\n'
+        '   e = mc^2\n'
+        '\n'
+        'See :class:`pkg.mod.Config`.\n'
+        '"""\n'
+        '\n'
+        'def use():\n'
+        '    """Applies :eq:`module-level-identity`."""\n'
+        '\n'
+        'class Config:\n'
+        '    pass\n',
+    )
+    g = graph.nxgraph
+    assert g.nodes["math:equation:module-level-identity"]["type"] \
+        == NodeType.EQUATION.value
+    # The module docstring's :class: reference became an edge too.
+    assert any(
+        d.get("type") == EdgeType.REFERENCES.value
+        and tgt == "py:class:pkg.mod.Config"
+        for _, tgt, d in g.out_edges("py:module:pkg.mod", data=True)
+    )
+    result = GraphQuery(graph).dead_references()
+    assert "module-level-identity" not in {d.target_name for d in result.dead}
+
+
 # ---------------------------------------------------------------------------
 # 3. Re-export aliases
 # ---------------------------------------------------------------------------

--- a/tests/test_dead_references.py
+++ b/tests/test_dead_references.py
@@ -1,0 +1,360 @@
+"""Dead-reference detection — the silent-drift gate.
+
+The drift shape (observed on ORPHEUS): a class is deleted or renamed,
+but theory pages, docstrings, and quoted type annotations still
+reference the old dotted path. Sphinx renders those references as plain
+text with no warning at any severity. These tests pin the whole
+pipeline that makes the graph gate-able on that shape:
+
+1. role-target parsing survives docstring line-wrapping;
+2. attributes and module constants exist as graph nodes, so live
+   ``:attr:``/``:data:`` references reconcile instead of looking dead;
+3. re-export aliases fold public-path phantoms onto defining nodes;
+4. project-rooted phantoms are never classified ``external`` just
+   because the project is pip-installed in its own build venv;
+5. ``GraphQuery.dead_references`` reports what is left, with
+   inheritance/re-export rescue passes guarding precision.
+"""
+
+from __future__ import annotations
+
+from sphinxcontrib.nexus.ast_analyzer import (
+    _chase_reexports,
+    _parse_role_target,
+    analyze_directory,
+)
+from sphinxcontrib.nexus.graph import (
+    EdgeType,
+    GraphEdge,
+    GraphNode,
+    KnowledgeGraph,
+    NodeType,
+)
+from sphinxcontrib.nexus.query import GraphQuery
+
+
+# ---------------------------------------------------------------------------
+# 1. Role-target parsing under line wrapping
+# ---------------------------------------------------------------------------
+
+
+def test_parse_wrapped_dotted_target():
+    """A dotted path wrapped across docstring lines collapses to a
+    clean target instead of forging a phantom with a newline in it."""
+    raw = "pkg.numerics.coupled_system.\n        CoupledField"
+    assert _parse_role_target(raw) == "pkg.numerics.coupled_system.CoupledField"
+
+
+def test_parse_wrapped_title_target_form():
+    """``title <target>`` spanning a line break still yields the
+    target between the angle brackets."""
+    raw = "pkg.mesh.Mesh.from_material\n        <pkg.mesh.Mesh.from_material>"
+    assert _parse_role_target(raw) == "pkg.mesh.Mesh.from_material"
+
+
+def test_parse_leading_dot_relative_target():
+    """Sphinx's ``.relative.target`` convention: dots are display
+    syntax, not part of the dotted path."""
+    assert _parse_role_target(".Quadrature.product") == "Quadrature.product"
+
+
+def test_parse_latex_body_untouched():
+    """Whitespace inside non-dotted content (inline math) is
+    meaningful and must not be collapsed."""
+    assert _parse_role_target("x + y") == "x + y"
+
+
+def test_parse_suppressed_and_tilde_still_work():
+    assert _parse_role_target("!pkg.mod.foo") is None
+    assert _parse_role_target("~pkg.mod.foo") == "pkg.mod.foo"
+
+
+# ---------------------------------------------------------------------------
+# 2. Attribute / data binding nodes
+# ---------------------------------------------------------------------------
+
+
+def _analyze_source(tmp_path, source: str) -> KnowledgeGraph:
+    (tmp_path / "pkg").mkdir(exist_ok=True)
+    (tmp_path / "pkg" / "__init__.py").write_text("")
+    (tmp_path / "pkg" / "mod.py").write_text(source)
+    return analyze_directory(tmp_path, exclude_patterns=[])
+
+
+def test_annotated_class_attribute_becomes_node(tmp_path):
+    graph = _analyze_source(
+        tmp_path,
+        "class Config:\n"
+        "    retries: int = 3\n"
+        "    name = 'x'\n",
+    )
+    g = graph.nxgraph
+    assert "py:attribute:pkg.mod.Config.retries" in g
+    assert "py:attribute:pkg.mod.Config.name" in g
+    retries = g.nodes["py:attribute:pkg.mod.Config.retries"]
+    assert retries["type"] == NodeType.ATTRIBUTE.value
+    assert retries["annotation"] == "int"
+    assert retries["file_path"].endswith("mod.py")
+    # CONTAINS from the class
+    assert any(
+        d.get("type") == EdgeType.CONTAINS.value
+        for _, _, d in g.edges("py:class:pkg.mod.Config", data=True)
+    )
+
+
+def test_module_constant_becomes_data_node(tmp_path):
+    graph = _analyze_source(tmp_path, "LIMIT = 10\nA, B = 1, 2\n")
+    g = graph.nxgraph
+    for name in ("LIMIT", "A", "B"):
+        nid = f"py:data:pkg.mod.{name}"
+        assert nid in g
+        assert g.nodes[nid]["type"] == NodeType.DATA.value
+
+
+def test_instance_attribute_in_init_becomes_node(tmp_path):
+    graph = _analyze_source(
+        tmp_path,
+        "class Solver:\n"
+        "    def __init__(self):\n"
+        "        self.mesh = None\n"
+        "        self.tol, self.max_iter = 1e-6, 100\n",
+    )
+    g = graph.nxgraph
+    for attr in ("mesh", "tol", "max_iter"):
+        assert f"py:attribute:pkg.mod.Solver.{attr}" in g
+
+
+def test_annotated_and_init_assignment_collapse_to_one_node(tmp_path):
+    graph = _analyze_source(
+        tmp_path,
+        "class Solver:\n"
+        "    tol: float\n"
+        "    def __init__(self):\n"
+        "        self.tol = 1e-6\n",
+    )
+    g = graph.nxgraph
+    nodes = [n for n in g.nodes if n == "py:attribute:pkg.mod.Solver.tol"]
+    assert len(nodes) == 1
+    # The annotated declaration won (it was emitted first, with the
+    # annotation recorded).
+    assert g.nodes[nodes[0]]["annotation"] == "float"
+
+
+# ---------------------------------------------------------------------------
+# 3. Re-export aliases
+# ---------------------------------------------------------------------------
+
+
+def test_chase_reexports_follows_chains_and_prefixes():
+    reexports = {
+        "pkg.Thing": "pkg.geometry.Thing",
+        "pkg.geometry.Thing": "pkg.geometry.mesh.Thing",
+    }
+    assert _chase_reexports("pkg.Thing", reexports) == "pkg.geometry.mesh.Thing"
+    # Prefix rewriting: a member accessed through the alias.
+    assert (
+        _chase_reexports("pkg.Thing.method", reexports)
+        == "pkg.geometry.mesh.Thing.method"
+    )
+
+
+def test_chase_reexports_survives_cycles():
+    reexports = {"a.X": "b.X", "b.X": "a.X"}
+    # Must terminate; landing on either side of the cycle is fine.
+    assert _chase_reexports("a.X", reexports) in ("a.X", "b.X")
+
+
+def test_reexport_map_collected_and_persisted(tmp_path):
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "__init__.py").write_text(
+        "from .core import Thing\n"
+    )
+    (tmp_path / "pkg" / "core.py").write_text("class Thing:\n    pass\n")
+    graph = analyze_directory(tmp_path, exclude_patterns=[])
+    assert graph.metadata["reexports"]["pkg.Thing"] == "pkg.core.Thing"
+
+
+def test_nonoverlapping_reexport_phantom_folds(tmp_path):
+    """The shape the leaf/module-path-overlap fold cannot catch:
+    ``pkg.api`` re-exports from ``pkg.core.thing`` — the module paths
+    neither prefix nor suffix each other, so only the alias map can
+    prove ``pkg.api.Thing`` is the same symbol."""
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "__init__.py").write_text("")
+    (tmp_path / "pkg" / "api").mkdir()
+    (tmp_path / "pkg" / "api" / "__init__.py").write_text(
+        "from pkg.core.thing import Thing\n"
+    )
+    (tmp_path / "pkg" / "core").mkdir()
+    (tmp_path / "pkg" / "core" / "__init__.py").write_text("")
+    (tmp_path / "pkg" / "core" / "thing.py").write_text(
+        "class Thing:\n    pass\n"
+    )
+    (tmp_path / "pkg" / "user.py").write_text(
+        'def use():\n'
+        '    """Uses :class:`pkg.api.Thing`."""\n'
+        '    return None\n'
+    )
+    graph = analyze_directory(tmp_path, exclude_patterns=[])
+    g = graph.nxgraph
+    # The phantom folded onto the defining node…
+    assert "py:class:pkg.api.Thing" not in g
+    # …and the docstring reference follows it there.
+    ref_targets = {
+        tgt for _, tgt, d in g.out_edges("py:function:pkg.user.use", data=True)
+        if d.get("type") == EdgeType.REFERENCES.value
+    }
+    assert "py:class:pkg.core.thing.Thing" in ref_targets
+
+
+# ---------------------------------------------------------------------------
+# 4. Project-rooted names never classify as external
+# ---------------------------------------------------------------------------
+
+
+def test_project_rooted_phantom_never_external(tmp_path, monkeypatch):
+    """The project is usually pip-installed in its own build venv, so
+    the installed-packages check alone would classify the project's own
+    dangling references as ``external`` and hide them from gating."""
+    import sphinxcontrib.nexus.extractors as extractors
+
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "__init__.py").write_text("")
+    (tmp_path / "pkg" / "mod.py").write_text(
+        'def f():\n'
+        '    """See :class:`pkg.deleted.Gone`."""\n'
+        '    return None\n'
+    )
+    # Simulate the project being importable in the build environment.
+    monkeypatch.setattr(
+        extractors,
+        "_EXTERNAL_NAMES",
+        frozenset(extractors._EXTERNAL_NAMES | {"pkg"}),
+    )
+    graph = analyze_directory(tmp_path, exclude_patterns=[])
+    attrs = graph.nxgraph.nodes["py:class:pkg.deleted.Gone"]
+    assert attrs["type"] == NodeType.UNRESOLVED.value
+
+
+# ---------------------------------------------------------------------------
+# 5. dead_references query
+# ---------------------------------------------------------------------------
+
+
+def _node(graph, nid, ntype, name, **meta):
+    graph.add_node(GraphNode(
+        id=nid, type=ntype, name=name, display_name=name.rsplit(".", 1)[-1],
+        domain="py", metadata=meta,
+    ))
+
+
+def _build_query_fixture() -> KnowledgeGraph:
+    kg = KnowledgeGraph()
+    _node(kg, "py:module:pkg", NodeType.MODULE, "pkg", file_path="/x/pkg/__init__.py")
+    _node(kg, "py:class:pkg.Base", NodeType.CLASS, "pkg.Base", file_path="/x/pkg/b.py")
+    _node(kg, "py:attribute:pkg.Base.attr", NodeType.ATTRIBUTE, "pkg.Base.attr",
+          file_path="/x/pkg/b.py")
+    _node(kg, "py:class:pkg.Sub", NodeType.CLASS, "pkg.Sub", file_path="/x/pkg/s.py")
+    kg.add_edge(GraphEdge(source="py:class:pkg.Sub", target="py:class:pkg.Base",
+                          type=EdgeType.INHERITS))
+    _node(kg, "py:class:pkg.SubExt", NodeType.CLASS, "pkg.SubExt",
+          file_path="/x/pkg/s.py")
+    _node(kg, "py:class:numpy.ndarray", NodeType.EXTERNAL, "numpy.ndarray")
+    kg.add_edge(GraphEdge(source="py:class:pkg.SubExt",
+                          target="py:class:numpy.ndarray",
+                          type=EdgeType.INHERITS))
+    _node(kg, "py:class:pkg.mod.Thing", NodeType.CLASS, "pkg.mod.Thing",
+          file_path="/x/pkg/mod.py")
+    kg.metadata["reexports"] = {"pkg.Alias": "pkg.mod.Thing"}
+
+    # The doc page holding the references.
+    kg.add_node(GraphNode(id="doc:page", type=NodeType.FILE, name="page",
+                          display_name="page", domain="std", docname="page"))
+
+    # Phantom targets.
+    _node(kg, "py:class:pkg.Gone", NodeType.UNRESOLVED, "pkg.Gone")
+    _node(kg, "py:attribute:pkg.Sub.attr", NodeType.UNRESOLVED, "pkg.Sub.attr")
+    _node(kg, "py:attribute:pkg.SubExt.attr", NodeType.UNRESOLVED,
+          "pkg.SubExt.attr")
+    _node(kg, "py:class:pkg.Alias", NodeType.UNRESOLVED, "pkg.Alias")
+    _node(kg, "py:class:numpy.gone", NodeType.EXTERNAL, "numpy.gone")
+    kg.add_node(GraphNode(id="math:equation:gone-label", type=NodeType.UNRESOLVED,
+                          name="gone-label", display_name="gone-label",
+                          domain="math"))
+    kg.add_node(GraphNode(id="math:equation:x_i", type=NodeType.UNRESOLVED,
+                          name="x_i", display_name="x_i", domain="math"))
+    kg.add_node(GraphNode(id="citation:Bell1970", type=NodeType.UNRESOLVED,
+                          name="Bell1970", display_name="Bell1970",
+                          domain="citation"))
+
+    def ref(target, edge_type=EdgeType.DOCUMENTS, **meta):
+        kg.add_edge(GraphEdge(source="doc:page", target=target, type=edge_type,
+                              metadata=meta))
+
+    ref("py:class:pkg.Gone")                                   # dead
+    ref("py:attribute:pkg.Sub.attr")                           # rescued: inherited
+    ref("py:attribute:pkg.SubExt.attr")                        # undecidable: opaque base
+    ref("py:class:pkg.Alias")                                  # rescued: re-export
+    ref("py:class:numpy.gone")                                 # skipped: external root
+    ref("math:equation:gone-label", EdgeType.EQUATION_REF)     # dead equation
+    ref("math:equation:x_i", EdgeType.REFERENCES, reftype="math")  # inline math, skipped
+    ref("citation:Bell1970", EdgeType.CITES)                   # citations skipped
+    return kg
+
+
+def test_dead_references_verdicts():
+    q = GraphQuery(_build_query_fixture())
+    result = q.dead_references()
+
+    dead_names = {d.target_name for d in result.dead}
+    assert dead_names == {"pkg.Gone", "gone-label"}
+    assert result.total_dead == 2
+    assert result.rescued == 2          # inherited attr + re-export alias
+    assert result.undecidable == 1      # opaque external base
+    assert result.total_checked == 5    # everything project-decidable
+    assert "pkg" in result.project_modules
+
+    by_name = {d.target_name: d for d in result.dead}
+    assert by_name["pkg.Gone"].kind == "python"
+    assert by_name["gone-label"].kind == "equation"
+    assert by_name["pkg.Gone"].sites[0].source.id == "doc:page"
+
+
+def test_staleness_carries_dead_references():
+    q = GraphQuery(_build_query_fixture())
+    result = q.staleness()  # no project_root: timestamp part skipped
+    assert result.total_dead_references == 2
+    assert {d.target_name for d in result.dead_references} == {
+        "pkg.Gone", "gone-label",
+    }
+
+
+def test_dead_references_end_to_end(tmp_path):
+    """Full pipeline: source → AST analysis → canonicalization →
+    query. One genuinely dead reference survives; live references to
+    an annotated attribute, a re-exported class, and a line-wrapped
+    target are all rescued."""
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "__init__.py").write_text(
+        "from .core import Thing\n"
+    )
+    (tmp_path / "pkg" / "core.py").write_text(
+        'class Thing:\n'
+        '    """A thing.\n'
+        '\n'
+        '    See :class:`pkg.deleted.Gone` for history, and\n'
+        '    :attr:`pkg.core.Config.retries` plus :class:`pkg.Thing`\n'
+        '    and the wrapped :class:`pkg.core.\n'
+        '        Config` reference.\n'
+        '    """\n'
+        '\n'
+        '    limit: int = 3\n'
+        '\n'
+        '\n'
+        'class Config:\n'
+        '    retries: int = 5\n'
+    )
+    graph = analyze_directory(tmp_path, exclude_patterns=[])
+    result = GraphQuery(graph).dead_references()
+    dead_names = {d.target_name for d in result.dead}
+    assert dead_names == {"pkg.deleted.Gone"}

--- a/tests/test_dead_references.py
+++ b/tests/test_dead_references.py
@@ -158,6 +158,70 @@ def test_chase_reexports_follows_chains_and_prefixes():
     )
 
 
+def test_nested_package_relative_reexport_resolves_fully(tmp_path):
+    """Regression: ``from .directional import Quadrature`` inside
+    ``pkg/numerics/quadrature/__init__.py`` must resolve against the
+    package ITSELF, not its parent — the parent-anchored resolution
+    dropped one segment from every re-export value in a nested
+    package (observed on ORPHEUS: 2,326 poisoned aliases)."""
+    root = tmp_path / "pkg" / "numerics" / "quadrature"
+    root.mkdir(parents=True)
+    (tmp_path / "pkg" / "__init__.py").write_text("")
+    (tmp_path / "pkg" / "numerics" / "__init__.py").write_text("")
+    (root / "__init__.py").write_text("from .directional import Quadrature\n")
+    (root / "directional.py").write_text("class Quadrature:\n    pass\n")
+    graph = analyze_directory(tmp_path, exclude_patterns=[])
+    assert graph.metadata["reexports"]["pkg.numerics.quadrature.Quadrature"] \
+        == "pkg.numerics.quadrature.directional.Quadrature"
+
+
+def test_subscripted_generic_base_gets_inherits_edge(tmp_path):
+    """Regression: ``class Full(Composite[A, B])`` — a Subscript base
+    — must still produce the INHERITS edge, or inherited-member
+    resolution breaks for every Generic-parameterized class."""
+    graph = _analyze_source(
+        tmp_path,
+        "from typing import Generic, TypeVar\n"
+        "T = TypeVar('T')\n"
+        "class Composite(Generic[T]):\n"
+        "    def __mul__(self, s):\n"
+        "        return self\n"
+        "    def scale(self, s):\n"
+        "        return self\n"
+        "class Full(Composite[int]):\n"
+        "    pass\n",
+    )
+    g = graph.nxgraph
+    inherits = {
+        tgt for _, tgt, d in g.out_edges("py:class:pkg.mod.Full", data=True)
+        if d.get("type") == EdgeType.INHERITS.value
+    }
+    assert "py:class:pkg.mod.Composite" in inherits
+
+
+def test_inherited_member_through_generic_base_is_live(tmp_path):
+    graph = _analyze_source(
+        tmp_path,
+        "from typing import Generic, TypeVar\n"
+        "T = TypeVar('T')\n"
+        "class Composite(Generic[T]):\n"
+        "    def scale(self, s):\n"
+        "        return self\n"
+        "class Full(Composite[int]):\n"
+        '    """See :meth:`pkg.mod.Full.scale` and\n'
+        '    :meth:`pkg.mod.Full.__mul__` and\n'
+        '    :meth:`pkg.mod.Full.vanished`."""\n',
+    )
+    result = GraphQuery(graph).dead_references()
+    dead_names = {d.target_name for d in result.dead}
+    # ``scale`` lives on the generic base; ``__mul__`` is an object-
+    # provided dunder on an existing class; ``vanished`` is genuinely
+    # missing — and typing.Generic must NOT make it undecidable.
+    assert "pkg.mod.Full.scale" not in dead_names
+    assert "pkg.mod.Full.__mul__" not in dead_names
+    assert "pkg.mod.Full.vanished" in dead_names
+
+
 def test_chase_reexports_survives_cycles():
     reexports = {"a.X": "b.X", "b.X": "a.X"}
     # Must terminate; landing on either side of the cycle is fine.

--- a/tests/test_dead_references.py
+++ b/tests/test_dead_references.py
@@ -140,6 +140,34 @@ def test_annotated_and_init_assignment_collapse_to_one_node(tmp_path):
     assert g.nodes[nodes[0]]["annotation"] == "float"
 
 
+def test_docstring_math_label_defines_equation_node(tmp_path):
+    """A ``.. math:: :label:`` block in a docstring DEFINES the label.
+    Sphinx only sees labels on rendered pages, so without AST-side
+    extraction every ``:eq:`` reference to a label defined in an
+    un-rendered docstring looks dead."""
+    graph = _analyze_source(
+        tmp_path,
+        'def derive():\n'
+        '    r"""The derivation.\n'
+        '\n'
+        '    .. math::\n'
+        '       :label: my-neat-identity\n'
+        '\n'
+        '       a^2 + b^2 = c^2\n'
+        '\n'
+        '    Used via :eq:`my-neat-identity` and :eq:`gone-label`.\n'
+        '    """\n',
+    )
+    g = graph.nxgraph
+    assert g.nodes["math:equation:my-neat-identity"]["type"] \
+        == NodeType.EQUATION.value
+
+    result = GraphQuery(graph).dead_references()
+    dead_names = {d.target_name for d in result.dead}
+    assert "my-neat-identity" not in dead_names
+    assert "gone-label" in dead_names
+
+
 # ---------------------------------------------------------------------------
 # 3. Re-export aliases
 # ---------------------------------------------------------------------------
@@ -364,6 +392,35 @@ def _build_query_fixture() -> KnowledgeGraph:
     ref("math:equation:x_i", EdgeType.REFERENCES, reftype="math")  # inline math, skipped
     ref("citation:Bell1970", EdgeType.CITES)                   # citations skipped
     return kg
+
+
+def test_inherited_member_via_public_reexport_path_is_live():
+    """Regression: ``pkg.Sink.zeros_on`` where ``pkg.Sink`` is a
+    re-export of ``pkg.impl.Sink`` AND ``zeros_on`` is only defined on
+    that class's base — the inheritance walk must run on the chased
+    spelling, not just the name as written."""
+    kg = KnowledgeGraph()
+    _node(kg, "py:module:pkg", NodeType.MODULE, "pkg", file_path="/x/p/__init__.py")
+    _node(kg, "py:class:pkg.impl.Sink", NodeType.CLASS, "pkg.impl.Sink",
+          file_path="/x/p/impl.py")
+    _node(kg, "py:class:pkg.impl.BaseField", NodeType.CLASS, "pkg.impl.BaseField",
+          file_path="/x/p/impl.py")
+    _node(kg, "py:method:pkg.impl.BaseField.zeros_on", NodeType.METHOD,
+          "pkg.impl.BaseField.zeros_on", file_path="/x/p/impl.py")
+    kg.add_edge(GraphEdge(source="py:class:pkg.impl.Sink",
+                          target="py:class:pkg.impl.BaseField",
+                          type=EdgeType.INHERITS))
+    kg.metadata["reexports"] = {"pkg.Sink": "pkg.impl.Sink"}
+    kg.add_node(GraphNode(id="doc:page", type=NodeType.FILE, name="page",
+                          display_name="page", domain="std", docname="page"))
+    _node(kg, "py:method:pkg.Sink.zeros_on", NodeType.UNRESOLVED,
+          "pkg.Sink.zeros_on")
+    kg.add_edge(GraphEdge(source="doc:page", target="py:method:pkg.Sink.zeros_on",
+                          type=EdgeType.DOCUMENTS))
+
+    result = GraphQuery(kg).dead_references()
+    assert result.total_dead == 0
+    assert result.rescued == 1
 
 
 def test_dead_references_verdicts():


### PR DESCRIPTION
## What

A deleted or renamed symbol leaves its doc references behind, and Sphinx renders them as plain text with **no warning at any severity** (the drift ORPHEUS hit and works around with `tools/check_docstring_xrefs.py`). The graph already contained the signal — reference edges whose target reconciles to nothing — but the phantom bucket ran ~83% false positives on ORPHEUS, so it couldn't be gated on. This PR makes it precise and surfaces it.

## New surface

- **`GraphQuery.dead_references()` + `dead_references` MCP tool** (39 → 40): every doc/docstring/type-annotation reference whose project-rooted target no longer exists, with all referencing sites. Only project-rooted names are judged (external refs are undecidable from the graph and never reported). Rescue passes: exact-name match, re-export chase, INHERITS walk (member on any ancestor = live; un-analyzed base = undecidable, never dead; `typing.Generic`/`Protocol`/`ABC`/`object` are transparent), dunder-on-existing-owner = live. Dead `:eq:` labels audited too; `:math:` roles ignored as presentation.
- **`staleness` now carries a dead-reference summary** (top 10 + total) alongside timestamp drift.

## Precision fixes (each one measured on ORPHEUS)

- AST walker emits **ATTRIBUTE/DATA nodes** (class annotations, `self.x` bindings, module constants) — the largest live-but-unmodeled bucket.
- **Re-export alias map** (`graph.metadata["reexports"]`) recorded from module-scope from-imports and chased during canonicalization + query rescue.
- **Package-relative imports were resolved one level short** inside nested-package `__init__.py` (2,326 poisoned aliases on ORPHEUS; also mangled base-class/call-target resolution — fabricated dead-looking names for symbols that had merely moved).
- **Subscripted generic bases** (`class Full(Composite[A, B])`) now produce INHERITS edges.
- **Module-level docstrings are now scanned** (previously skipped entirely) and **`.. math:: :label:` definitions in docstrings become equation nodes** — Sphinx only learns labels from rendered pages.
- **Project-rooted names never classify as `external`** (both classifier copies checked installed packages first; the project is pip-installed in its own build venv).
- **Line-wrapped role targets normalize** instead of forging newline-bearing phantoms.

## Validation (fresh ORPHEUS build, import-resolution as ground truth)

| metric | result |
|---|---|
| referenced phantom targets checked | 43 |
| rescued by precision passes | 23 |
| undecidable | 0 |
| reported dead | 20 |
| false positives on real code | **0** |
| genuinely missing symbols | 15 |
| README-only namespace dirs (no code — defensible dead) | 5 |
| dead equations after docstring-label extraction | 0 |
| moved symbols wrongly reported | 0 |

552 tests pass (23 new in `tests/test_dead_references.py`), pyright clean, README tool registry drift-guard updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PTrKtfrCB3znVo5fhLHRe