### PR TITLE
fix: usage-evidence tunings from the issue #15 evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,23 @@ docstring refs) resolve to their new homes instead of being reported.
   `pkg.core.thing.Thing` even when the module paths don't overlap, which
   the leaf-name fold could never prove.
 
+### Changed — usage-evidence tunings (issue #15)
+
+Seven weeks of real ORPHEUS sessions (806 journaled tool calls, 842 injected
+edit-time briefs, zero tool failures) settled the deferred tuning decisions:
+
+- **Ambient file-brief drops its staleness line.** The line fired on 842 of
+  842 injected briefs — the hook runs post-edit, where "file changed since
+  graph build" is tautologically true. The ``changed_since_build`` field
+  stays on the dataclass/JSON.
+- **Sibling-graph warning now fires only when a sibling's graph is FRESHER
+  than the active one.** Existence alone produced 39 warnings against 4
+  actual workspace switches. Siblings are still listed either way.
+- **No token budgets added to `callers`/`callees`/`neighbors`/`graph_query`**
+  — the journal shows no payload bombs (slow calls were non-transitive on
+  ordinary nodes; the latency tail is database reload after a rebuild, not
+  hub payloads).
+
 ### Fixed
 
 - **Package-relative imports resolved one level short.** `ImportTracker`

--- a/sphinxcontrib/nexus/brief.py
+++ b/sphinxcontrib/nexus/brief.py
@@ -341,10 +341,11 @@ def render_text(brief: FileBrief) -> str:
         )
     if brief.doc_pages:
         lines.append(f"docs: {_clipped(brief.doc_pages)}")
-    if brief.changed_since_build:
-        lines.append(
-            f"stale: file changed since graph build "
-            f"({brief.build_commit}) — node positions may be off; "
-            f"rebuild to refresh"
-        )
+    # No per-file staleness line here, deliberately: the ambient form's
+    # consumer is the POST-EDIT hook, where "file changed since graph
+    # build" is tautologically true (the agent just edited it). Issue
+    # #15's usage evaluation measured the line at a 100% fire rate —
+    # 842 of 842 injected briefs — i.e. zero information. The
+    # ``changed_since_build`` field stays on the dataclass/JSON for
+    # consumers that ask at other times.
     return "\n".join(lines)

--- a/sphinxcontrib/nexus/server.py
+++ b/sphinxcontrib/nexus/server.py
@@ -273,11 +273,24 @@ def _workspace_payload() -> dict[str, Any]:
                 f"the graph, or switch with use_workspace if you meant "
                 f"another checkout"
             )
-    if any(o["has_graph"] for o in others):
+    # Warn about sibling graphs only when one is FRESHER than the
+    # active graph — the mere existence of sibling graphs fired 39
+    # warnings across 6 real sessions against 4 workspace switches
+    # (issue #15 evaluation): existence alone is noise, freshness is
+    # the actionable signal.
+    fresher = [
+        s for s in statuses
+        if not s.is_active
+        and s.graph_mtime is not None
+        and (active.graph_mtime is None or s.graph_mtime > active.graph_mtime)
+    ]
+    if fresher:
+        roots = ", ".join(str(s.workspace.root) for s in fresher[:3])
         warnings.append(
-            "sibling worktrees with their own graphs exist — if your "
-            "session is working inside one of them, call "
-            "use_workspace(<its root>) so queries answer from that tree"
+            f"sibling checkout(s) carry a FRESHER graph than the active "
+            f"one ({roots}) — if your session is working inside one of "
+            f"them, call use_workspace(<its root>) so queries answer "
+            f"from that tree"
         )
     if warnings:
         payload["warnings"] = warnings

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -299,7 +299,11 @@ def test_brief_flags_file_changed_since_build(stamped_repo):
     brief = file_brief(db, target, project_root=root)
     assert brief is not None
     assert brief.changed_since_build is True
-    assert "stale" in render_text(brief)
+    # The FIELD carries the flag; the ambient TEXT deliberately does
+    # not — its consumer is the post-edit hook, where "changed since
+    # build" is tautologically true (issue #15: 842/842 briefs carried
+    # the line — zero information).
+    assert "stale" not in render_text(brief)
 
 
 def test_brief_other_files_changing_does_not_flag(stamped_repo):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -545,10 +545,33 @@ def test_briefing_workspace_block_flags_branch_mismatch(server_on_main):
 
 
 def test_briefing_workspace_block_notes_sibling_graphs(server_on_main, worktree):
+    """A sibling graph FRESHER than the active one triggers the
+    switch hint (this one was written after the active graph)."""
     _write_graph(worktree, "feature_node")
     block = server_mod._workspace_payload()
     assert any("use_workspace" in w for w in block["warnings"])
     assert block["active"]["branch"] == "main"
+    assert len(block["others"]) == 1
+
+
+def test_briefing_stale_sibling_graph_stays_quiet(server_on_main, worktree):
+    """A sibling whose graph is OLDER than the active one is not
+    worth a warning — existence alone fired 39 warnings against 4
+    switches in real sessions (issue #15); freshness is the signal."""
+    import os
+
+    repo = server_on_main
+    _write_graph(worktree, "feature_node")
+    active_mtime = (repo / DB_RELPATH).stat().st_mtime
+    stale = active_mtime - 100
+    os.utime(worktree / DB_RELPATH, (stale, stale))
+
+    block = server_mod._workspace_payload()
+    assert not any(
+        "use_workspace(<its root>)" in w
+        for w in block.get("warnings", [])
+    )
+    # The sibling is still LISTED — only the warning is gated.
     assert len(block["others"]) == 1
 
 


### PR DESCRIPTION
Implements the two tuning decisions mandated by the #15 usage-evidence evaluation (full evaluation posted on the issue):

- **Ambient file-brief drops its staleness line** — fired on 842/842 injected briefs (the hook runs post-edit, so "changed since build" is always true). Field remains on the dataclass/JSON.
- **Sibling-graph warning gates on freshness** — 39 warnings vs 4 actual switches in real sessions; now warns only when a sibling's graph is newer than the active one, siblings still listed.
- **Decision recorded, no code**: no token budgets for `callers`/`callees`/`neighbors`/`graph_query` — the journal shows the latency tail is database reload after rebuilds, not hub payload bombs.

553 tests pass, pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PTrKtfrCB3znVo5fhLHRe