### PR TITLE
feat: port to mcp 2.x + guard resolver-borne breaks (closes #31)

### DIFF
--- a/.github/workflows/upstream-deps.yml
+++ b/.github/workflows/upstream-deps.yml
@@ -1,0 +1,91 @@
+# Upstream dependency watch.
+#
+# CI only runs on pushes and PRs, so a break that arrives through the
+# DEPENDENCY RESOLVER rather than a commit is invisible by construction.
+# That is not hypothetical: mcp 2.0.0 removed `mcp.server.fastmcp` and
+# main stayed red — and every fresh install shipped a server that could
+# not start — from 2026-06-17 to 2026-08-09, because no commit triggered
+# a run that would have shown it.
+#
+# This job installs with the newest resolvable dependencies on a schedule
+# and opens an issue when that fails, so an upstream major surfaces as a
+# dated alert instead of an archaeology exercise.
+
+name: Upstream deps
+
+on:
+  schedule:
+    # Mondays 06:00 UTC — a fresh break is found within a week, and the
+    # report lands at the start of a working week rather than during one.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  latest-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install with newest resolvable dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade --upgrade-strategy eager -e ".[test]"
+
+      - name: Record resolved versions
+        id: versions
+        run: |
+          python -m pip freeze | grep -iE '^(mcp|sphinx|networkx|pyyaml)==' \
+            | tee resolved.txt
+
+      # The spawn test is the one that matters here: an incompatible
+      # upstream typically imports fine and fails only when a client
+      # launches the server.
+      - name: Run tests against the newest resolution
+        id: tests
+        run: python -m pytest tests/ -q
+
+      - name: Report a break as an issue
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let resolved = '(pip freeze unavailable)';
+            try { resolved = fs.readFileSync('resolved.txt', 'utf8'); } catch (e) {}
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const title = 'Upstream dependency break: newest resolution fails CI';
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'upstream-break',
+            });
+            const body = [
+              'The scheduled newest-dependency install failed.',
+              '',
+              'Pinned ranges in `pyproject.toml` still protect released installs,',
+              'but this is the signal that an upstream release has moved past us.',
+              '',
+              '```',
+              resolved.trim(),
+              '```',
+              '',
+              `Run: ${run}`,
+            ].join('\n');
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: existing.data[0].number, body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: ['upstream-break'],
+              });
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to sphinxcontrib-nexus.
 
 ## Unreleased
 
+### Changed — ported to the mcp 2.x server API
+
+`mcp` 2.0.0 removed `mcp.server.fastmcp`. The previous release bounded the
+dependency `<2` to stop shipping a dead server; this completes the move.
+
+- `server.py` now builds on `mcp.server.mcpserver.MCPServer` (the `FastMCP`
+  successor). The decorator surface is unchanged — `@_mcp.tool()`,
+  `@_mcp.resource(uri)`, `Context`, `ctx.session` — so the 40 tools, 4
+  resources and the journaling wrapper port without restructuring. Verified:
+  `functools.wraps` transparency still holds, and `Context` parameters are
+  still excluded from public tool schemas.
+- **Breaking upstream rename**: `Tool.inputSchema` → `Tool.input_schema`.
+  Only the registry drift-guard read it.
+- Dependency floor is now `mcp>=2.0`, pinned to the import by a test — the
+  floor and the import are one fact stored twice, and a future bump must
+  move both.
+
+### Added — the guards that would have caught this two months earlier
+
+- **`tests/test_server_spawn.py`** launches the server as a real subprocess
+  and completes a JSON-RPC handshake. Every other server test inspects the
+  registry in-process, which is precisely why mcp 2.0.0 shipped a dead
+  server undetected: the package imported fine, the CLI worked, and no test
+  ever launched the process a client launches. Verified to fail when pointed
+  at the removed module. Unmarked and unskippable — a test you can skip is a
+  test that will be skipped on the day it matters.
+- **`.github/workflows/upstream-deps.yml`** installs with the newest
+  resolvable dependencies weekly and opens (or comments on) an issue when
+  that fails. CI runs only on pushes and PRs, so a break arriving through
+  the resolver rather than a commit is invisible by construction — this one
+  sat from 2026-06-17 to 2026-08-09.
+
 ### Dead-reference detection — the silent doc-drift gate
 
 A deleted or renamed symbol leaves its doc references behind, and Sphinx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ sphinxcontrib/nexus/
                         stamping, `git worktree` discovery
     export.py         — JSON + SQLite (FTS5) export/import,
                         read_sqlite_metadata (metadata peek without full load)
-    server.py         — FastMCP server; module-global state = ONE workspace
+    server.py         — MCP server (mcp 2.x `MCPServer`); module-global
+                        state = ONE workspace
                         per server process (one agent session); mtime-based
                         auto-reload under _reload_lock
     cli.py            — `nexus` CLI (setup, analyze, serve, workspaces, …)
@@ -70,7 +71,7 @@ sphinxcontrib/nexus/
 
 ## Drift surfaces (guarded by tests — keep them green)
 
-- README "MCP Tools (N)" header and tool bullets ↔ FastMCP registry
+- README "MCP Tools (N)" header and tool bullets ↔ MCP registry
   (`tests/test_server_registry.py`).
 - Version is single-sourced in `sphinxcontrib/nexus/__init__.py`
   (`__version__`); `pyproject.toml` declares it `dynamic` and flit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,11 @@ keywords = [
 dependencies = [
     "Sphinx>=7.0",
     "networkx>=3.0",
-    # Upper bound is load-bearing: mcp 2.0.0 REMOVED `mcp.server.fastmcp`,
-    # which server.py is built on, so an unpinned install silently ships a
-    # broken MCP server (import error at startup, every tool unavailable).
-    # Migrating to the 2.x server API is tracked separately — until then
-    # this bound is the difference between a working and a dead install.
-    "mcp>=1.0,<2",
+    # Floor is load-bearing: `mcp.server.mcpserver.MCPServer` (the 1.x
+    # `FastMCP` successor) does not exist before 2.0, and 2.0 renamed
+    # `Tool.inputSchema` → `input_schema`. server.py targets the 2.x API,
+    # so an older mcp fails at import rather than degrading.
+    "mcp>=2.0",
     "PyYAML>=6.0",
 ]
 classifiers = [

--- a/sphinxcontrib/nexus/server.py
+++ b/sphinxcontrib/nexus/server.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
 
-from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.mcpserver import Context, MCPServer
 
 from sphinxcontrib.nexus._serialize import (
     assemble_communities,
@@ -51,7 +51,7 @@ from sphinxcontrib.nexus.workspace import (
 
 logger = logging.getLogger(__name__)
 
-_mcp = FastMCP("nexus", instructions=(
+_mcp = MCPServer("nexus", instructions=(
     "Knowledge graph server for code and documentation. "
     "Query relationships between functions, classes, equations, "
     "theory pages, and external dependencies."
@@ -64,7 +64,8 @@ _query: GraphQuery | None = None
 _workspace: Workspace | None = None
 _db_mtime: float = 0.0
 
-# Reload coordination: FastMCP may dispatch tool calls concurrently,
+# Reload coordination: the MCP server may dispatch tool calls
+# concurrently,
 # and the mid-reload state (new ``_query`` assigned but ``_db_mtime``
 # not yet updated) is short but real. The lock serializes the
 # reload path so a second concurrent caller sees the finalized
@@ -85,7 +86,7 @@ def _reload_if_stale() -> None:
 
     Thread-safe: a module-level lock serializes the mtime check
     and the atomic ``_query`` / ``_db_mtime`` swap so concurrent
-    FastMCP tool dispatches can't observe a half-updated state.
+    MCP tool dispatches can't observe a half-updated state.
     """
     global _query, _db_mtime
     if _workspace is None:

--- a/tests/test_python_floor.py
+++ b/tests/test_python_floor.py
@@ -83,18 +83,37 @@ def test_sources_parse_on_the_declared_python_floor():
     )
 
 
-def test_mcp_dependency_excludes_the_release_that_removed_fastmcp():
-    """`mcp` 2.0.0 removed `mcp.server.fastmcp`, which `server.py` imports.
+def test_mcp_floor_matches_the_api_server_targets():
+    """`server.py` targets the mcp **2.x** API.
 
-    An unpinned `mcp>=1.0` resolves to 2.x and produces an install whose
-    MCP server cannot start — every tool silently unavailable, with the
-    failure surfacing only at server spawn. Keep the bound until the
-    server is ported to the 2.x API.
+    History worth keeping: 2.0.0 removed `mcp.server.fastmcp`, and for
+    two months an unpinned `mcp>=1.0` resolved to it and shipped installs
+    whose MCP server could not start — the package imports fine and the
+    CLI works, so the failure surfaced only at server spawn. The server
+    is now ported to `mcp.server.mcpserver.MCPServer`, which does not
+    exist before 2.0, so the FLOOR is what keeps the two in step.
     """
     text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    match = re.search(r'"mcp>=[^"]*"', text)
+    match = re.search(r'"mcp>=(\d+)\.(\d+)[^"]*"', text)
     assert match, "mcp dependency not found in pyproject.toml"
-    assert "<2" in match.group(0), (
-        "mcp must stay bounded below 2.0 while server.py imports "
-        "mcp.server.fastmcp, which 2.0.0 removed"
+    major = int(match.group(1))
+    assert major >= 2, (
+        "server.py imports mcp.server.mcpserver, which requires mcp>=2.0; "
+        f"pyproject declares {match.group(0)}"
+    )
+
+
+def test_server_imports_the_api_the_dependency_promises():
+    """The import in `server.py` and the floor in `pyproject.toml` are one
+    fact stored twice. This pins them together so a future bump cannot
+    move one without the other."""
+    source = (ROOT / "sphinxcontrib" / "nexus" / "server.py").read_text(
+        encoding="utf-8"
+    )
+    assert "from mcp.server.mcpserver import" in source, (
+        "server.py no longer imports the mcp 2.x server API — update "
+        "the dependency floor in pyproject.toml in the same commit"
+    )
+    assert "fastmcp" not in source, (
+        "mcp.server.fastmcp was removed in mcp 2.0.0"
     )

--- a/tests/test_server_registry.py
+++ b/tests/test_server_registry.py
@@ -1,7 +1,7 @@
 """README ↔ MCP registry drift guard.
 
 The tool count and tool list in README.md have drifted from the
-FastMCP registry repeatedly (serve's help said 16, a consumer's docs
+MCP registry repeatedly (serve's help said 16, a consumer's docs
 said 20, README said 27 — all at the same time). The registry is the
 single source of truth; this module pins the README to it so the next
 added/renamed tool fails CI instead of silently drifting.
@@ -83,9 +83,9 @@ def test_skill_reference_documents_every_tool():
 
 def test_journal_wrapper_preserves_parameter_schemas():
     """The nexus_tool journaling wrapper must stay schema-transparent:
-    FastMCP introspects through functools.wraps/__wrapped__, so tool
+    MCPServer introspects through functools.wraps/__wrapped__, so tool
     parameters survive and Context params stay excluded."""
-    schemas = {t.name: t.inputSchema for t in asyncio.run(_mcp.list_tools())}
+    schemas = {t.name: t.input_schema for t in asyncio.run(_mcp.list_tools())}
     assert set(schemas["impact"]["properties"]) == {
         "target", "direction", "max_depth", "edge_types", "limit_per_depth",
     }

--- a/tests/test_server_spawn.py
+++ b/tests/test_server_spawn.py
@@ -1,0 +1,119 @@
+"""End-to-end: does the MCP server actually START and serve tools?
+
+Every other server test imports `server.py` in-process and inspects the
+registry. That is exactly the blind spot that let mcp 2.0.0 ship a dead
+server for two months: `mcp.server.fastmcp` had been removed, so an
+install resolved to 2.x could not spawn at all — yet the package
+imported fine, the CLI worked, and every unit test passed, because
+nothing ever launched the process an MCP client would launch.
+
+This test launches it the way a client does — a subprocess speaking
+JSON-RPC over stdio — and completes the handshake. It is deliberately
+the slowest test in the suite (~10s); that cost buys the one signal the
+fast tests structurally cannot give. No marker gates it — this repo runs
+plain pytest with no marker taxonomy, and a test you can skip is a test
+that will be skipped on the day it matters.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp import Client  # noqa: E402
+from mcp.client.stdio import StdioServerParameters, stdio_client  # noqa: E402
+
+from sphinxcontrib.nexus.export import write_sqlite  # noqa: E402
+from sphinxcontrib.nexus.graph import (  # noqa: E402
+    EdgeType,
+    GraphEdge,
+    GraphNode,
+    KnowledgeGraph,
+    NodeType,
+)
+
+
+def _tiny_graph(db_path: Path) -> None:
+    kg = KnowledgeGraph()
+    kg.add_node(GraphNode(
+        id="py:module:pkg", type=NodeType.MODULE, name="pkg",
+        display_name="pkg", domain="py",
+        metadata={"file_path": "/x/pkg/__init__.py"},
+    ))
+    kg.add_node(GraphNode(
+        id="py:function:pkg.solve", type=NodeType.FUNCTION, name="pkg.solve",
+        display_name="solve", domain="py",
+        metadata={"file_path": "/x/pkg/a.py", "lineno": 1},
+    ))
+    kg.add_edge(GraphEdge(
+        source="py:module:pkg", target="py:function:pkg.solve",
+        type=EdgeType.CONTAINS,
+    ))
+    write_sqlite(kg, db_path)
+
+
+async def _handshake(db_path: Path) -> tuple[list[str], str]:
+    """Spawn `nexus serve` and complete a real client handshake."""
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "sphinxcontrib.nexus.cli", "serve", "--db", str(db_path)],
+    )
+    # `stdio_client(params)` IS the transport (an async context manager
+    # yielding the stream pair); Client enters it. Passing a string here
+    # would mean an HTTP URL, not a command.
+    async with Client(stdio_client(params)) as client:
+        listed = await client.list_tools()
+        result = await client.call_tool("stats", {})
+    # The client returns the protocol result model, not a bare list —
+    # iterating the model itself yields (field, value) pairs, which is a
+    # quiet way to get nonsense rather than an error.
+    tools = getattr(listed, "tools", listed)
+    text = ""
+    for block in result.content:
+        text += getattr(block, "text", "")
+    return sorted(t.name for t in tools), text
+
+
+def test_server_spawns_and_serves_tools(tmp_path):
+    db = tmp_path / "graph.db"
+    _tiny_graph(db)
+
+    try:
+        names, stats_text = asyncio.run(asyncio.wait_for(_handshake(db), 90))
+    except asyncio.TimeoutError:  # pragma: no cover - CI hang guard
+        pytest.fail("MCP server did not complete a handshake within 90s")
+
+    # The registry is asserted elsewhere; here the point is that a CLIENT
+    # can reach it at all, over a real process boundary.
+    assert names, "server started but advertised no tools"
+    assert "stats" in names
+    assert "dead_references" in names
+    # And that a call round-trips actual graph content, not just metadata.
+    assert "pkg.solve" in stats_text or "function" in stats_text
+
+
+def test_spawned_tool_count_matches_the_in_process_registry(tmp_path):
+    """A client sees exactly the tools the module registers — catches a
+    transport/serialization regression that drops or renames tools."""
+    from sphinxcontrib.nexus.server import _mcp
+
+    db = tmp_path / "graph.db"
+    _tiny_graph(db)
+    names, _ = asyncio.run(asyncio.wait_for(_handshake(db), 90))
+    in_process = sorted(t.name for t in asyncio.run(_mcp.list_tools()))
+    assert names == in_process
+
+
+def test_cli_module_is_executable():
+    """`python -m sphinxcontrib.nexus.cli` is how the spawn test (and any
+    venv-less MCP config) launches the server."""
+    assert shutil.which(sys.executable)
+    from sphinxcontrib.nexus import cli
+
+    assert hasattr(cli, "main")


### PR DESCRIPTION
Closes #31.

## The port

`mcp` 2.0's `MCPServer` is a near drop-in for `FastMCP` — `@tool()`, `@resource(uri)`, `Context`, `ctx.session` all survive — so the 40 tools and 4 resources move without restructuring. I verified the two contracts that could have broken *silently* before touching anything:

- `functools.wraps` schema transparency through the journaling wrapper (tool parameters survive introspection)
- `Context` parameters still excluded from public tool schemas

One breaking upstream rename found: **`Tool.inputSchema` → `Tool.input_schema`**. Only the registry drift-guard read it.

Dependency floor is now `mcp>=2.0`, pinned to the import by assertion — the floor and the import are one fact stored twice, so a future bump has to move both deliberately rather than one silently.

**588 tests pass on mcp 2.0.0, on both 3.14 and the declared 3.10 floor.**

## The part that actually matters

The port was never the hard part. *Noticing* was — this shipped a non-functional server for two months. So this PR closes the two structural holes that allowed it:

**`tests/test_server_spawn.py`** launches the server as a real subprocess and completes a JSON-RPC handshake. Every other server test inspects the registry in-process, which is exactly the blind spot: with mcp 2.x installed the package imported fine, the CLI worked, every test passed — and no test ever launched the process an MCP client launches. I confirmed the new test fails when aimed at the removed module, then reverted.

It carries no marker and cannot be skipped. This repo runs plain pytest with no marker taxonomy (per `CLAUDE.md`), and a test you can skip is a test that will be skipped on the day it matters.

**`.github/workflows/upstream-deps.yml`** installs the newest resolvable dependencies weekly and opens (or comments on) an issue when that fails. CI triggers on pushes and PRs only, so a break arriving through the **dependency resolver** rather than a commit is invisible by construction — no commit was ever going to run the check that would have caught this.

## Note on the pin direction

`mcp>=2.0` (floor) rather than a range: `mcp.server.mcpserver` does not exist before 2.0, so an older resolution now fails loudly at import instead of degrading. That is the correct failure direction for this dependency — the whole incident was a failure that stayed quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PTrKtfrCB3znVo5fhLHRe