### PR TITLE
chore: release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to sphinxcontrib-nexus.
 
 ## Unreleased
 
+## 0.16.0 — 2026-08-09
+
+**Headline:** a new doc-drift gate (`dead_references`, MCP tools 39 → 40), a
+`nexus setup` that treats the consuming project as a peer rather than a cache,
+push channels for findings that must not be missed, a measured eval suite for
+the instruction surface — and the mcp 2.x port that ends two months of shipping
+a server that could not start.
+
+**Upgrade note:** this release requires **`mcp>=2.0`**. Environments with an
+editable or pinned older `mcp` must upgrade (`pip install "mcp>=2.0"`), or the
+MCP server will fail at import. Installs of 0.15.0 and earlier that resolved
+`mcp` 2.x have a non-functional server and should upgrade to this release.
+
 ### Changed — ported to the mcp 2.x server API
 
 `mcp` 2.0.0 removed `mcp.server.fastmcp`. The previous release bounded the

--- a/sphinxcontrib/nexus/__init__.py
+++ b/sphinxcontrib/nexus/__init__.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Bumps `__version__` to 0.16.0 and cuts the Unreleased changelog section.

## What ships

- **`dead_references`** — the doc-drift gate this whole cycle started from (MCP tools 39 → 40), with a CLI, a `/doc-health` slash command and a `SessionStart` hook so a finding nothing else reports gets pushed rather than hoped for.
- **`nexus setup` as a two-way channel** — always-on routing rule, `--check`/`--diff`, and no silent clobbering of a consumer's edits (including their `.mcp.json`).
- **Skill steering, measured** — a symptom→tool surface validated by an eval suite that ships in `evals/`, plus the `nexus-elegance` skill harvested from the consuming project.
- **The mcp 2.x port**, ending two months of shipping a server that could not start.

## Upgrade note (in the changelog too)

This release **requires `mcp>=2.0`**. Environments with an editable or pinned older `mcp` must upgrade or the server fails at import. Anyone on 0.15.0 or earlier whose `mcp` resolved to 2.x already has a non-functional server and should take this release.

## Pre-tag verification

Rather than trusting a green test suite, I built the wheel and used it from a clean venv the way a PyPI user would:

- `nexus setup` — 16 files, 10 skills, rule, command and hook all present (confirmed the wheel actually carries them; flit missing them would make setup useless from PyPI)
- `nexus analyze` on a fixture, then `nexus dead-references` correctly reporting a live dead reference with file:line
- **a real MCP server spawn over stdio advertising all 40 tools**

That last check is the one whose absence allowed 0.15.0's broken server: a build that imports is not a build that runs.

588 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PTrKtfrCB3znVo5fhLHRe