### PR TITLE
fix: /doc-health emitted nothing (bare `nexus` is not on PATH) — 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to sphinxcontrib-nexus.
 
 ## Unreleased
 
+## 0.16.1 — 2026-08-09
+
+### Fixed
+
+- **`/doc-health` produced an empty report on every project.** The shipped
+  slash command invoked a bare `nexus`, which is not on PATH in the normal
+  layout — the binary lives in the project's `.venv/bin/`. Both `!` lines
+  resolved to `command not found`, so the command looked installed, reported
+  nothing, and the drift it exists to surface stayed invisible. It now
+  resolves the binary the way the hook already did (project venv first, PATH
+  as fallback), honours `NEXUS_DB`, and prints an explanation instead of a
+  blank when the graph or binary is missing.
+
+  A push channel that silently emits nothing is worse than no channel, so
+  `tests/test_push_channels.py` now **executes the shipped shell** — the
+  command's `!` lines and the hook — against a real graph with `nexus`
+  deliberately absent from PATH. Verified to fail against the 0.16.0 form.
+
 ## 0.16.0 — 2026-08-09
 
 **Headline:** a new doc-drift gate (`dead_references`, MCP tools 39 → 40), a

--- a/sphinxcontrib/nexus/__init__.py
+++ b/sphinxcontrib/nexus/__init__.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"
 
 logger = logging.getLogger(__name__)
 

--- a/sphinxcontrib/nexus/commands/doc-health.md
+++ b/sphinxcontrib/nexus/commands/doc-health.md
@@ -1,6 +1,6 @@
 ---
 description: Documentation health — dead references and drift, computed now
-allowed-tools: Bash(nexus:*)
+allowed-tools: Bash
 ---
 
 The following was computed from the knowledge graph at the moment you were
@@ -8,11 +8,11 @@ invoked. It is a finding, not a suggestion to go look for one.
 
 ## Dead documentation references
 
-!`nexus dead-references --db docs/_build/html/_nexus/graph.db --format text --limit 25`
+!`N="${CLAUDE_PROJECT_DIR:-.}/.venv/bin/nexus"; [ -x "$N" ] || N="$(command -v nexus 2>/dev/null)"; D="${NEXUS_DB:-${CLAUDE_PROJECT_DIR:-.}/docs/_build/html/_nexus/graph.db}"; if [ -n "$N" ] && [ -f "$D" ]; then "$N" dead-references --db "$D" --format text --limit 25; else echo "(nexus or graph not found — run 'nexus setup' and build the docs; set NEXUS_DB to override the graph path)"; fi`
 
 ## Timestamp drift
 
-!`nexus staleness --db docs/_build/html/_nexus/graph.db 2>/dev/null | head -40`
+!`N="${CLAUDE_PROJECT_DIR:-.}/.venv/bin/nexus"; [ -x "$N" ] || N="$(command -v nexus 2>/dev/null)"; D="${NEXUS_DB:-${CLAUDE_PROJECT_DIR:-.}/docs/_build/html/_nexus/graph.db}"; if [ -n "$N" ] && [ -f "$D" ]; then "$N" staleness --db "$D" 2>/dev/null | head -40; fi`
 
 ---
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -263,9 +263,18 @@ def test_doc_health_command_injects_rather_than_asks(tmp_path):
 
     import sphinxcontrib.nexus as nexus_pkg
 
+    import re
+
     text = (Path(nexus_pkg.__file__).parent
             / "commands" / "doc-health.md").read_text()
-    assert "!`nexus dead-references" in text
+    executed = re.findall(r"^!`(.+)`$", text, re.MULTILINE)
+    # Assert the PROPERTY (a `!` line runs the query), not one spelling of
+    # the invocation — the binary must be resolved rather than assumed on
+    # PATH, so the exact command text is expected to change.
+    assert any("dead-references" in line for line in executed), (
+        "no `!` line runs dead-references — the command would be asking "
+        "the agent to look rather than handing it the finding"
+    )
     assert "allowed-tools:" in text
 
 

--- a/tests/test_push_channels.py
+++ b/tests/test_push_channels.py
@@ -1,0 +1,177 @@
+"""The push channels must work in the environment they actually run in.
+
+Both channels exist to deliver a finding to an agent that never asked for
+it. A channel that silently produces nothing is worse than no channel: it
+looks installed, reports clean, and the drift it was meant to surface goes
+on being invisible.
+
+The shipped `/doc-health` command did exactly that in its first release —
+it invoked a bare `nexus`, which is not on PATH in the normal layout
+(the binary lives in the project's `.venv/bin/`). Every `!` line resolved
+to `command not found` and the command injected an empty report. Nothing
+caught it, because nothing ever ran those lines.
+
+So these tests EXECUTE the shipped shell, with `nexus` deliberately absent
+from PATH, against a real graph.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from sphinxcontrib.nexus.export import write_sqlite
+from sphinxcontrib.nexus.graph import (
+    EdgeType,
+    GraphEdge,
+    GraphNode,
+    KnowledgeGraph,
+    NodeType,
+)
+
+PACKAGE = Path(__file__).resolve().parents[1] / "sphinxcontrib" / "nexus"
+COMMAND = PACKAGE / "commands" / "doc-health.md"
+HOOK = PACKAGE / "hooks" / "nexus-dead-refs.sh"
+
+
+def _graph_with_a_dead_reference(db_path: Path) -> None:
+    """A graph whose docs cite a symbol that does not exist."""
+    kg = KnowledgeGraph()
+    kg.add_node(GraphNode(
+        id="py:module:pkg", type=NodeType.MODULE, name="pkg",
+        display_name="pkg", domain="py",
+        metadata={"file_path": "/x/pkg/__init__.py"},
+    ))
+    kg.add_node(GraphNode(
+        id="py:class:pkg.mod.Thing", type=NodeType.CLASS, name="pkg.mod.Thing",
+        display_name="Thing", domain="py",
+        metadata={"file_path": "/x/pkg/mod.py", "lineno": 1},
+    ))
+    kg.add_node(GraphNode(
+        id="py:class:pkg.gone.Missing", type=NodeType.UNRESOLVED,
+        name="pkg.gone.Missing", display_name="Missing", domain="py",
+    ))
+    kg.add_edge(GraphEdge(
+        source="py:class:pkg.mod.Thing", target="py:class:pkg.gone.Missing",
+        type=EdgeType.REFERENCES,
+    ))
+    write_sqlite(kg, db_path)
+
+
+def _venv_layout(tmp_path: Path) -> Path:
+    """A project whose nexus lives in `.venv/bin/`, as after `nexus setup`.
+
+    The console script is a shim onto the interpreter running the tests, so
+    the shipped resolution logic is exercised without building a venv.
+    """
+    binary = tmp_path / ".venv" / "bin" / "nexus"
+    binary.parent.mkdir(parents=True, exist_ok=True)
+    binary.write_text(
+        "#!/bin/sh\n"
+        f'exec "{sys.executable}" -m sphinxcontrib.nexus.cli "$@"\n'
+    )
+    binary.chmod(0o755)
+    return binary
+
+
+def _shell_lines(markdown: str) -> list[str]:
+    """The `` !`…` `` lines a slash command executes at invocation."""
+    return re.findall(r"^!`(.+)`$", markdown, re.MULTILINE)
+
+
+def _scrubbed_env(project: Path) -> dict[str, str]:
+    """PATH without any `nexus`, plus the project dir the command reads.
+
+    This is the whole point: the failure only appears when the binary is
+    NOT globally installed, which is the normal case.
+    """
+    env = dict(os.environ)
+    env["PATH"] = "/usr/bin:/bin"
+    env["CLAUDE_PROJECT_DIR"] = str(project)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    return env
+
+
+def test_doc_health_command_runs_without_nexus_on_path(tmp_path):
+    _venv_layout(tmp_path)
+    db = tmp_path / "docs" / "_build" / "html" / "_nexus" / "graph.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    _graph_with_a_dead_reference(db)
+
+    lines = _shell_lines(COMMAND.read_text())
+    assert lines, "the command has no `!` lines — it injects nothing"
+
+    first = subprocess.run(
+        ["bash", "-c", lines[0]],
+        cwd=tmp_path, env=_scrubbed_env(tmp_path),
+        capture_output=True, text=True,
+    )
+    assert first.returncode == 0, first.stderr
+    # The finding itself must be present — not a "command not found" and
+    # not the graceful fallback, both of which would inject nothing useful.
+    assert "DEAD DOCUMENTATION REFERENCES" in first.stdout, first.stdout
+    assert "pkg.gone.Missing" in first.stdout
+    assert "not found" not in first.stderr.lower()
+
+
+def test_doc_health_degrades_readably_when_there_is_no_graph(tmp_path):
+    """A project that hasn't built docs yet must get an explanation, not a
+    silent blank or a shell error."""
+    _venv_layout(tmp_path)
+    lines = _shell_lines(COMMAND.read_text())
+    proc = subprocess.run(
+        ["bash", "-c", lines[0]],
+        cwd=tmp_path, env=_scrubbed_env(tmp_path),
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "not found" in proc.stdout.lower()
+    assert "nexus setup" in proc.stdout
+
+
+def test_hook_emits_additional_context_without_nexus_on_path(tmp_path):
+    _venv_layout(tmp_path)
+    db = tmp_path / "docs" / "_build" / "html" / "_nexus" / "graph.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    _graph_with_a_dead_reference(db)
+
+    proc = subprocess.run(
+        ["bash", str(HOOK)],
+        cwd=tmp_path, env=_scrubbed_env(tmp_path),
+        capture_output=True, text=True, input="",
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "additionalContext" in proc.stdout
+    assert "pkg.gone.Missing" in proc.stdout
+
+
+def test_hook_stays_silent_on_a_clean_project(tmp_path):
+    """No findings must cost zero context, or the channel trains agents to
+    skim past it on the day it matters."""
+    _venv_layout(tmp_path)
+    db = tmp_path / "docs" / "_build" / "html" / "_nexus" / "graph.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    write_sqlite(KnowledgeGraph(), db)
+
+    proc = subprocess.run(
+        ["bash", str(HOOK)],
+        cwd=tmp_path, env=_scrubbed_env(tmp_path),
+        capture_output=True, text=True, input="",
+    )
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_no_shipped_channel_assumes_nexus_is_on_path():
+    """Guards the class of bug rather than the instance: every shipped
+    invocation must resolve the binary, never assume PATH."""
+    for path in (COMMAND, HOOK):
+        text = path.read_text()
+        for line in _shell_lines(text) if path is COMMAND else [text]:
+            assert ".venv/bin/nexus" in line, (
+                f"{path.name} invokes nexus without resolving it against "
+                f"the project venv; PATH is not a safe assumption"
+            )


### PR DESCRIPTION
Found by auditing the real consumer after 0.16.0 landed.

## The bug

The shipped `/doc-health` command invoked `nexus` unqualified:

```
!`nexus dead-references --db docs/_build/html/_nexus/graph.db --format text --limit 25`
```

In the normal layout the binary lives in the project's `.venv/bin/`, not on PATH:

```
$ nexus dead-references --db docs/_build/html/_nexus/graph.db
bash: nexus: command not found
```

So both `!` lines produced nothing and the command injected an **empty report**. It looked installed and reported clean, while the drift it exists to surface stayed invisible — the precise failure mode the push channels were built to eliminate, reintroduced by the channel itself.

Inconsistent with the `.mcp.json` template (which correctly uses `${CLAUDE_PROJECT_DIR:-.}/.venv/bin/nexus`) and with the hook (which already resolved the venv first). Only the command assumed PATH.

## The fix

The command now mirrors the hook's proven resolution — project venv first, PATH fallback — honours `NEXUS_DB`, and prints an explanation rather than a blank when the binary or graph is missing.

## The guard that should have existed

Nothing caught this because nothing ever *ran* those lines — the same shape as the mcp 2.0 outage, where nothing ever spawned the server. `tests/test_push_channels.py` now **executes the shipped shell** with `nexus` deliberately scrubbed from PATH, against a real graph containing a real dead reference:

- the command's `!` line must emit the actual finding
- it must degrade readably when there's no graph yet
- the hook must emit valid `additionalContext`, and stay **silent** on a clean project
- no shipped invocation may assume PATH

Verified: three of these fail against the 0.16.0 form.

593 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PTrKtfrCB3znVo5fhLHRe