### PR TITLE
feat(graph): equation relations + sphinx-proof nodes (#19, #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,63 @@ All notable changes to sphinxcontrib-nexus.
 
 ## Unreleased
 
+### Added — the math has structure now (#19, #21)
+
+Equations were graph leaves. The graph knew which code implemented an equation
+and which test verified it, but nothing about how the equations relate to each
+other — so `provenance_chain` returned a flat list where a validator wants a
+spine.
+
+**Statement relations** (#19). Three directives declare that structure:
+
+```rst
+.. math::
+   :label: sn-dd-closure
+
+   \psi_c = \tfrac{1}{2}(\psi_L + \psi_R)
+
+.. discretizes:: sn-transport-continuous
+```
+
+- `discretizes` — discrete form → the continuous one it discretizes
+- `derives-from` — specialization → its parent
+- `approximates` — closure/truncation → the exact form it stands in for
+
+Each names its target as the argument; the source comes from `:label:` or, when
+omitted, from the nearest preceding labeled statement — which is where these get
+written in practice, directly under the equation they describe. New `EdgeType`
+values `DISCRETIZES` / `DERIVES_FROM` / `APPROXIMATES`, tagged
+`source="directive"` like the existing verification directives and surviving
+incremental builds through the same pending queue.
+
+Misuse warns and is dropped, never breaking the build: no bindable source, a
+statement related to itself, or a target that doesn't exist.
+
+**sphinx-proof environments** (#21). Every *labeled* `prf:` environment —
+definition, theorem, algorithm, and the dozen others — becomes a `proof_object`
+node carrying its title, its statement text, and its kind in
+`metadata["prf_type"]`. The `prf` domain exposes neither `object_types` nor
+`get_objects()`, so these are read from `env.proof_list` and enriched from the
+doctree; `:prf:ref:` targets resolve to the new nodes, which matters because an
+unresolved one would otherwise surface as a false dead reference.
+
+One node type rather than fifteen: the environment kind is an attribute and the
+node id (`prf:theorem:thm-balance`) already carries it. Unlabeled environments
+are skipped — sphinx-proof gives them a serial-numbered synthetic label that
+renumbers whenever anything above them moves, and nothing can reference them.
+
+Both ends of a relation may be an equation *or* a proof environment, so
+*Theorem 3.4 derives-from Definition 3.2* needs no new syntax.
+
+**Consumed by `provenance_chain`**, which now returns a `relations` list of
+`source ─relation→ target` triples reachable from the queried node — from a
+code symbol, an equation, or a proof environment. Each link is reported once,
+in its authored direction.
+
+Tested against a real `sphinx-proof` build (`tests/roots/test-proof-relations`)
+rather than a fixture guess, since the whole point is what the upstream
+extension actually publishes. `sphinx-proof` is now a test-only dependency.
+
 ## 0.16.1 — 2026-08-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -94,13 +94,14 @@ Nexus works with any Python project:
 
 ## What the Graph Contains
 
-### Node Types (15)
+### Node Types (16)
 
 | Type | Source | Example |
 |------|--------|---------|
 | `file` | Sphinx | RST/doc pages |
 | `section` | Sphinx | Labeled sections (`:ref:` targets) |
 | `equation` | Sphinx | Labeled math equations (`:eq:` targets) |
+| `proof_object` | Sphinx | A labeled [`sphinx-proof`](https://github.com/executablebooks/sphinx-proof) environment — definition, theorem, algorithm, … The environment kind is in `metadata["prf_type"]`, the prose in `metadata["statement"]` |
 | `term` | Sphinx | Glossary terms |
 | `function` | Sphinx + AST | Python functions |
 | `class` | Sphinx + AST | Python classes |
@@ -114,7 +115,7 @@ Nexus works with any Python project:
 | `unresolved` | Auto-detected | Referenced but not documented symbols |
 | `tag` | AST | A string/enum value a function discriminates on (`"spherical"`), target of `discriminates_on` |
 
-### Edge Types (13)
+### Edge Types (16)
 
 | Edge | Meaning | Source |
 |------|---------|--------|
@@ -131,6 +132,9 @@ Nexus works with any Python project:
 | `tests` | Test → tested function | AST |
 | `derives` | Derivation → equation | AST |
 | `discriminates_on` | Function → tag it branches on (`if x == "..."`, `match`) | AST |
+| `discretizes` | Discrete statement → the continuous one it discretizes | Directive |
+| `derives_from` | Specialization → the parent it was reduced from | Directive |
+| `approximates` | Closure/truncation → the exact form it stands in for | Directive |
 
 ## MCP Tools (40)
 
@@ -318,6 +322,40 @@ Declare verification edges directly in theory prose:
 ```
 
 Both directives accept an explicit `:by:` option naming the Python symbol. When omitted, they fall back to inspecting `env.ref_context` so usage nested inside `.. py:function::` / `.. autofunction::` blocks picks up the enclosing signature automatically. Directive edges are tagged `source="directive"` and survive incremental builds via a docname-keyed pending queue with an `env-purge-doc` handler.
+
+### Relating equations to each other
+
+Equations used to be graph leaves: code implemented them, tests verified them, and that was all the graph knew. Three directives declare the structure of the math itself, so `provenance_chain` returns a spine instead of a flat list — *this test verifies the discrete form, which discretizes this continuous one*:
+
+```rst
+.. math::
+   :label: sn-dd-closure
+
+   \psi_c = \tfrac{1}{2}(\psi_L + \psi_R)
+
+.. discretizes:: sn-transport-continuous
+```
+
+| Directive | Declares |
+|-----------|----------|
+| `discretizes` | This discrete form discretizes that continuous one |
+| `derives-from` | This specialization derives from that parent |
+| `approximates` | This closure or truncation approximates that exact form |
+
+Each names its **target** as the argument. The **source** comes from `:label:`, or — when omitted, as above — from the nearest preceding labeled statement, which is where these are written in practice. Either end may be a `math` equation or a `sphinx-proof` environment, so *Theorem 3.4 derives-from Definition 3.2* uses the same syntax:
+
+```rst
+.. derives-from:: def-angular-flux
+   :label: thm-balance
+```
+
+Misuse is loud and never breaks the build: a directive with no bindable source, one that relates a statement to itself, or one whose target doesn't exist warns and is dropped.
+
+### sphinx-proof environments
+
+When a project uses [`sphinx-proof`](https://github.com/executablebooks/sphinx-proof), every **labeled** `prf:` environment becomes a `proof_object` node carrying its title, its statement text, and its kind in `metadata["prf_type"]`. `:prf:ref:` cross-references resolve to those nodes, and a `prf:algorithm` sitting next to the function that runs it makes the math-name ↔ code-name bridge explicit.
+
+Unlabeled environments are skipped: sphinx-proof gives them a serial-numbered synthetic label that renumbers whenever anything above them moves, and nothing can reference them.
 
 ### From a registry YAML
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,9 @@ Issues = "https://github.com/deOliveira-R/sphinxcontrib-nexus/issues"
 nexus = "sphinxcontrib.nexus.cli:main"
 
 [project.optional-dependencies]
-test = ["pytest"]
+# sphinx-proof is optional for users but required to test the `prf`
+# extractor against a real build rather than a hand-built fixture.
+test = ["pytest", "sphinx-proof"]
 dev = ["ruff", "mypy"]
 viz = []  # Sigma.js loaded from CDN, no Python deps needed
 

--- a/sphinxcontrib/nexus/_mappings.py
+++ b/sphinxcontrib/nexus/_mappings.py
@@ -53,6 +53,34 @@ DOMAIN_TYPE_MAP: dict[tuple[str, str], NodeType] = {
     ("std", "doc"): NodeType.FILE,
 }
 
+# ``sphinx-proof`` environment names. The upstream ``prf`` domain exposes
+# neither ``object_types`` nor ``get_objects()`` — everything lives in
+# ``env.proof_list`` — so the list can't be derived from the domain and is
+# kept here instead. It is used to resolve a bare ``:prf:ref:`` label (which
+# carries no environment name) to a ``prf:<type>:<label>`` node id.
+#
+# Not imported from ``sphinx_proof``: a graph built elsewhere can contain
+# prf nodes while the local environment has no sphinx-proof installed, so
+# the list has to stand on its own. ``resolve_target_id`` falls back to a
+# prefix scan for any type added upstream after this was written.
+PRF_OBJECT_TYPES: tuple[str, ...] = (
+    "algorithm",
+    "assumption",
+    "axiom",
+    "conjecture",
+    "corollary",
+    "criterion",
+    "definition",
+    "example",
+    "lemma",
+    "notation",
+    "observation",
+    "property",
+    "proposition",
+    "remark",
+    "theorem",
+)
+
 # Map pending_xref reftype to EdgeType.
 REFTYPE_EDGE_MAP: dict[str, EdgeType] = {
     "ref": EdgeType.REFERENCES,
@@ -75,6 +103,30 @@ REFTYPE_EDGE_MAP: dict[str, EdgeType] = {
     "envvar": EdgeType.REFERENCES,
     "citation": EdgeType.CITES,
 }
+
+
+def resolve_proof_id(nxgraph: nx.MultiDiGraph, label: str) -> str | None:
+    """Resolve a bare ``sphinx-proof`` label to its node id.
+
+    ``:prf:ref:`sn-sweep``` names the label but not the environment, so
+    the id has to be reconstructed by trying each known environment.
+    Returns ``None`` when no proof object carries the label.
+    """
+    for objtype in PRF_OBJECT_TYPES:
+        nid = f"prf:{objtype}:{label}"
+        if nid in nxgraph:
+            return nid
+    # An environment sphinx-proof grew after PRF_OBJECT_TYPES was
+    # written. Scan rather than report a live reference as dead.
+    tail = f":{label}"
+    for node_id in nxgraph:
+        if (
+            isinstance(node_id, str)
+            and node_id.startswith("prf:")
+            and node_id.endswith(tail)
+        ):
+            return node_id
+    return None
 
 
 def resolve_target_id(
@@ -100,6 +152,8 @@ def resolve_target_id(
     if reftype == "eq":
         nid = f"math:equation:{reftarget}"
         return nid if nid in nxgraph else None
+    if refdomain == "prf":
+        return resolve_proof_id(nxgraph, reftarget)
 
     # Collect candidate obj_types for this reftype
     candidate_objtypes = [reftype]

--- a/sphinxcontrib/nexus/directives.py
+++ b/sphinxcontrib/nexus/directives.py
@@ -1,6 +1,8 @@
 """Sphinx directives for declaring verification and implementation edges.
 
-Two user-facing directives ship in v0.8.0:
+Two families of user-facing directives ship here.
+
+**Math ↔ code** (v0.8.0):
 
 - ``.. verifies:: <equation_label>`` — declares that a Python object
   verifies (tests) a math equation. Emits an ``EdgeType.TESTS`` edge.
@@ -11,6 +13,25 @@ Both take an optional ``:by:`` role that names the Python symbol. When
 omitted, the directive falls back to ``env.ref_context`` inspection so
 usage nested inside an ``.. py:function::`` or ``.. autofunction::``
 block picks up the enclosing signature automatically.
+
+**Math ↔ math** (v0.17.0): equations were graph leaves — the graph knew
+code implements them and tests verify them, but nothing about how the
+math itself hangs together. Three directives declare that structure:
+
+- ``.. discretizes:: <label>`` — this discrete form discretizes that
+  continuous one.
+- ``.. derives-from:: <label>`` — this specialization/reduction derives
+  from that parent.
+- ``.. approximates:: <label>`` — this closure/truncation approximates
+  that exact form.
+
+Each names its *target* as the argument and takes the *source*
+statement as ``:label:``. Omit ``:label:`` and the directive binds to
+the nearest preceding labelled equation in the same document, which is
+where these are written in practice — directly under the equation they
+describe. Both ends may name a ``math`` equation or a ``sphinx-proof``
+environment, so "Theorem 3.4 derives-from Definition 3.2" works with
+the same syntax.
 
 **Timing**: directives run during ``doctree-read``, before
 ``env.nexus_graph`` exists. They stash pending edge payloads on
@@ -29,6 +50,8 @@ from docutils import nodes
 from docutils.parsers.rst import directives as rst_directives
 from sphinx.util.docutils import SphinxDirective
 
+from sphinxcontrib.nexus._mappings import resolve_proof_id
+from sphinxcontrib.nexus.extractors import _is_auto_proof_label
 from sphinxcontrib.nexus.graph import EdgeType
 
 if TYPE_CHECKING:
@@ -37,6 +60,15 @@ if TYPE_CHECKING:
     from sphinx.environment import BuildEnvironment
 
 logger = logging.getLogger(__name__)
+
+#: Directive name → edge type for the statement-to-statement relations.
+#: Every entry must have a query that consumes it (``provenance_chain``
+#: walks all three); the set stays small on purpose.
+EQUATION_RELATIONS: dict[str, EdgeType] = {
+    "discretizes": EdgeType.DISCRETIZES,
+    "derives-from": EdgeType.DERIVES_FROM,
+    "approximates": EdgeType.APPROXIMATES,
+}
 
 
 def _init_pending_queue(
@@ -104,6 +136,147 @@ def _node_id_for_target(target: str, graph: "nx.MultiDiGraph") -> str | None:
         if candidate in graph:
             return candidate
     return None
+
+
+def _resolve_statement_id(label: str, graph: "nx.MultiDiGraph") -> str | None:
+    """Resolve a label naming a mathematical statement to a node id.
+
+    A statement is either a ``math`` equation or a ``sphinx-proof``
+    environment; both are written as a bare label at the directive, so
+    which one it is only becomes knowable against the built graph.
+    """
+    eq_id = f"math:equation:{label}"
+    if eq_id in graph:
+        return eq_id
+    return resolve_proof_id(graph, label)
+
+
+def _nearest_preceding_label(state: Any) -> str | None:
+    """The label of the last labelled statement parsed before this point.
+
+    These directives are written directly beneath the equation they talk
+    about, so the enclosing statement is nearly always the one just
+    above — the same ergonomics ``:by:`` gets from ``ref_context``.
+    Only content already parsed is attached to the document, so the last
+    match in document order *is* the nearest preceding one.
+
+    Matches labelled ``.. math::`` blocks and sphinx-proof environments
+    (identified structurally by their ``realtype`` attribute, so no
+    import of the optional extension is needed). Synthetic labels from
+    unlabelled proof environments are skipped — they name nothing the
+    graph will hold, so binding to one would only produce a confusing
+    "not found" at replay.
+    """
+    document = getattr(state, "document", None)
+    if document is None:
+        return None
+    found: str | None = None
+    for node in document.findall(nodes.Element):
+        label = node.get("label")
+        if not label:
+            continue
+        realtype = node.get("realtype")
+        if realtype:
+            if not _is_auto_proof_label(label, realtype):
+                found = label
+        elif isinstance(node, nodes.math_block):
+            found = label
+    return found
+
+
+class _StatementRelationDirective(SphinxDirective):
+    """Common plumbing for the statement-to-statement relations.
+
+    Deliberately not a subclass of ``_VerificationDirectiveBase``: the
+    two share only the pending queue. This family takes no ``:by:``
+    (neither end is code) and its source is a label rather than a
+    ref_context lookup, so inheriting would mean overriding everything
+    that matters.
+    """
+
+    required_arguments = 1
+    has_content = True
+    option_spec = {
+        "label": rst_directives.unchanged,
+    }
+
+    #: Subclasses set this to a key of ``EQUATION_RELATIONS``.
+    kind: str = ""
+
+    def run(self) -> list[nodes.Node]:
+        to_label = self.arguments[0].strip()
+        from_label = (
+            self.options.get("label", "").strip()
+            or _nearest_preceding_label(self.state)
+            or ""
+        )
+        if not from_label:
+            msg = self.reporter.warning(
+                f".. {self.kind}:: {to_label!r} needs a ':label:' option "
+                f"(no labelled equation or proof environment precedes it)",
+                line=self.lineno,
+            )
+            return [msg]
+        if from_label == to_label:
+            msg = self.reporter.warning(
+                f".. {self.kind}:: {to_label!r} relates a statement to "
+                f"itself — check the ':label:' option",
+                line=self.lineno,
+            )
+            return [msg]
+
+        pending = _init_pending_queue(self.env, self.env.docname)
+        pending.append({
+            "kind": self.kind,
+            "from_label": from_label,
+            "to_label": to_label,
+            "docname": self.env.docname,
+            "lineno": self.lineno,
+        })
+        if self.content:
+            container = nodes.container()
+            self.state.nested_parse(self.content, self.content_offset, container)
+            return [container]
+        return []
+
+
+class DiscretizesDirective(_StatementRelationDirective):
+    """Declare that a discrete form discretizes a continuous one.
+
+    Syntax::
+
+        .. math::
+           :label: sn-dd-closure
+
+           \\dots
+
+        .. discretizes:: sn-transport-continuous
+
+    Emits ``EdgeType.DISCRETIZES`` from ``sn-dd-closure`` to
+    ``sn-transport-continuous``.
+    """
+
+    kind = "discretizes"
+
+
+class DerivesFromDirective(_StatementRelationDirective):
+    """Declare that a specialization derives from a parent statement.
+
+    Emits ``EdgeType.DERIVES_FROM`` from the specialized statement to
+    the general one it was reduced from.
+    """
+
+    kind = "derives-from"
+
+
+class ApproximatesDirective(_StatementRelationDirective):
+    """Declare that a closure or truncation approximates an exact form.
+
+    Emits ``EdgeType.APPROXIMATES`` from the approximation to the exact
+    statement it stands in for.
+    """
+
+    kind = "approximates"
 
 
 class _VerificationDirectiveBase(SphinxDirective):
@@ -184,6 +357,52 @@ class ImplementsDirective(_VerificationDirectiveBase):
     kind = "implements"
 
 
+def _apply_relation(
+    entry: dict[str, Any],
+    graph: "nx.MultiDiGraph",
+    ctx: str,
+) -> int:
+    """Write one statement-to-statement edge. Returns 1 if it landed.
+
+    Both ends must already exist as nodes. A label that resolves to
+    nothing is a dead reference in prose — logged and skipped, the same
+    treatment the verification directives give a missing equation.
+    """
+    kind = entry["kind"]
+    from_label = entry["from_label"]
+    to_label = entry["to_label"]
+
+    source_id = _resolve_statement_id(from_label, graph)
+    if source_id is None:
+        logger.warning(
+            ".. %s:: [%s]: source statement %r not found in graph — skipping",
+            kind, ctx, from_label,
+        )
+        return 0
+
+    target_id = _resolve_statement_id(to_label, graph)
+    if target_id is None:
+        logger.warning(
+            ".. %s:: [%s]: target statement %r not found in graph — skipping",
+            kind, ctx, to_label,
+        )
+        return 0
+
+    edge_type = EQUATION_RELATIONS[kind].value
+    existing = graph.get_edge_data(source_id, target_id, default={})
+    if any(d.get("type") == edge_type for d in existing.values()):
+        return 0
+
+    graph.add_edge(
+        source_id,
+        target_id,
+        type=edge_type,
+        source="directive",
+        confidence=1.0,
+    )
+    return 1
+
+
 def apply_pending_edges(
     env: "BuildEnvironment",
     graph: "nx.MultiDiGraph",
@@ -216,10 +435,15 @@ def apply_pending_edges(
     for docname, entries in registry.items():
         for entry in entries:
             kind = entry["kind"]
-            label = entry["label"]
-            target = entry["target"]
             lineno = entry.get("lineno", "?")
             ctx = f"{docname}:{lineno}"
+
+            if kind in EQUATION_RELATIONS:
+                written += _apply_relation(entry, graph, ctx)
+                continue
+
+            label = entry["label"]
+            target = entry["target"]
 
             resolved = _node_id_for_target(target, graph)
             if resolved is None:
@@ -312,8 +536,11 @@ def merge_env(
 
 
 def register(app: "Sphinx") -> None:
-    """Register the verification directives and their env handlers."""
+    """Register the nexus directives and their env handlers."""
     app.add_directive("verifies", VerifiesDirective)
     app.add_directive("implements", ImplementsDirective)
+    app.add_directive("discretizes", DiscretizesDirective)
+    app.add_directive("derives-from", DerivesFromDirective)
+    app.add_directive("approximates", ApproximatesDirective)
     app.connect("env-purge-doc", purge_doc)
     app.connect("env-merge-info", merge_env)

--- a/sphinxcontrib/nexus/extractors.py
+++ b/sphinxcontrib/nexus/extractors.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from docutils import nodes as docutils_nodes
 from sphinx import addnodes
 
 from sphinxcontrib.nexus._mappings import (
@@ -112,6 +113,119 @@ def extract_domain_objects(env: BuildEnvironment, graph: KnowledgeGraph) -> None
                 ))
 
 
+def _is_auto_proof_label(label: str, realtype: str) -> bool:
+    """True for the synthetic label sphinx-proof gives an unlabelled block.
+
+    An environment written without ``:label:`` gets ``<type>-<serialno>``,
+    where the serial is a per-build counter — it shifts whenever anything
+    above it moves. Such a block is also unreferenceable by design
+    (``noindex`` is forced on). Admitting them would churn node ids on
+    every edit and add nodes no query can reach.
+    """
+    if not label.startswith(f"{realtype}-"):
+        return False
+    return label[len(realtype) + 1:].isdigit()
+
+
+def _proof_title(title: str) -> str:
+    """The environment's own title, without the rendering wrapper.
+
+    sphinx-proof stores the title already formatted by
+    ``proof_title_format``, whose default ``"(%t)"`` produces
+    ``"(Angular flux)"`` so it reads as *Definition 1 (Angular flux)* on
+    the page. Only the name belongs in a node's display_name, so a
+    single matched outer pair of parens comes off.
+    """
+    title = title.strip()
+    if len(title) > 2 and title.startswith("(") and title.endswith(")"):
+        inner = title[1:-1]
+        # Bail on "(a) and (b)" — the outer parens aren't a wrapper there.
+        if "(" not in inner and ")" not in inner:
+            return inner.strip()
+    return title
+
+
+def _proof_statement_text(node: docutils_nodes.Element, limit: int = 400) -> str:
+    """The environment's prose, whitespace-collapsed and truncated.
+
+    ``env.proof_list`` records where a theorem lives but not what it
+    says, and what it says is the part worth reading — in ``context``
+    output today, as an embedding target once semantic search lands.
+    """
+    for child in node.children:
+        if isinstance(child, docutils_nodes.section):
+            text = " ".join(child.astext().split())
+            if len(text) > limit:
+                return text[:limit].rstrip() + "…"
+            return text
+    return ""
+
+
+def extract_proof_objects(env: BuildEnvironment, graph: KnowledgeGraph) -> None:
+    """Create a node for every labelled ``sphinx-proof`` environment.
+
+    The ``prf`` domain implements neither ``object_types`` nor
+    ``get_objects()`` — every environment is recorded on
+    ``env.proof_list`` instead — so the generic domain walk in
+    :func:`extract_domain_objects` sees nothing and these have to be
+    read directly, exactly as the math domain is.
+
+    No-op when sphinx-proof isn't installed or no environment is used.
+    """
+    proof_list = getattr(env, "proof_list", None) or {}
+    for label, info in proof_list.items():
+        realtype = info.get("realtype", "")
+        docname = info.get("docname", "")
+        if not realtype or _is_auto_proof_label(label, realtype):
+            continue
+
+        node_id = _node_id("prf", realtype, label)
+        graph.add_node(GraphNode(
+            id=node_id,
+            type=NodeType.PROOF_OBJECT,
+            name=label,
+            display_name=label,
+            domain="prf",
+            docname=docname,
+            anchor=label,
+            metadata={
+                "prf_type": realtype,
+                "numbered": not info.get("nonumber", False),
+            },
+        ))
+
+        doc_id = _doc_node_id(docname)
+        if graph.has_node(doc_id):
+            graph.add_edge(GraphEdge(
+                source=doc_id,
+                target=node_id,
+                type=EdgeType.CONTAINS,
+            ))
+
+
+def _enrich_proof_nodes(doctree: docutils_nodes.document, graph: KnowledgeGraph) -> None:
+    """Attach title and statement text to proof nodes from one doctree.
+
+    Piggy-backs on the doctree load :func:`extract_references` already
+    pays for. Proof nodes are matched structurally (a ``realtype`` and a
+    ``label`` attribute) so the optional extension is never imported.
+    """
+    for node in doctree.findall(docutils_nodes.Element):
+        realtype = node.get("realtype")
+        label = node.get("label")
+        if not realtype or not label:
+            continue
+        attrs = graph.nxgraph.nodes.get(_node_id("prf", realtype, label))
+        if attrs is None:
+            continue
+        title = _proof_title(node.get("title") or "")
+        if title:
+            attrs["display_name"] = title
+        statement = _proof_statement_text(node)
+        if statement:
+            attrs["statement"] = statement
+
+
 def _is_valid_identifier(reftarget: str) -> bool:
     """Check if reftarget looks like a real Python/RST identifier.
 
@@ -215,6 +329,12 @@ def _get_project_modules(env: BuildEnvironment) -> frozenset[str]:
 def extract_references(env: BuildEnvironment, graph: KnowledgeGraph) -> None:
     """Walk doctrees for pending_xref nodes and create edges."""
     project_modules = _get_project_modules(env)
+    # The enrichment pass is a full doctree traversal per page. Most
+    # projects have no proof environments at all — check once rather
+    # than pay for it on every document.
+    enrich_proofs = any(
+        isinstance(n, str) and n.startswith("prf:") for n in graph.nxgraph
+    )
 
     for docname in env.all_docs:
         try:
@@ -222,6 +342,9 @@ def extract_references(env: BuildEnvironment, graph: KnowledgeGraph) -> None:
         except Exception:
             logger.debug("Could not load doctree for %s", docname)
             continue
+
+        if enrich_proofs:
+            _enrich_proof_nodes(doctree, graph)
 
         source_id = _doc_node_id(docname)
         seen_edges: set[tuple[str, str, str]] = set()  # (source, target, edge_type)
@@ -312,5 +435,7 @@ def build_graph(env: BuildEnvironment) -> KnowledgeGraph:
     graph = KnowledgeGraph()
     extract_documents(env, graph)
     extract_domain_objects(env, graph)
+    # Before references: an xref can only resolve to a node that exists.
+    extract_proof_objects(env, graph)
     extract_references(env, graph)
     return graph

--- a/sphinxcontrib/nexus/graph.py
+++ b/sphinxcontrib/nexus/graph.py
@@ -25,6 +25,12 @@ class NodeType(str, Enum):
     EXTERNAL = "external"
     UNRESOLVED = "unresolved"
     TAG = "tag"
+    #: A ``sphinx-proof`` environment — definition, theorem, lemma,
+    #: algorithm, and the dozen other ``prf:`` types. One node type for
+    #: all of them, with the specific environment kept in the node id
+    #: (``prf:theorem:label``) and in ``metadata["prf_type"]``; fifteen
+    #: near-identical NodeTypes would buy nothing a filter can't.
+    PROOF_OBJECT = "proof_object"
 
 
 class EdgeType(str, Enum):
@@ -39,8 +45,16 @@ class EdgeType(str, Enum):
     INHERITS = "inherits"
     TYPE_USES = "type_uses"
     TESTS = "tests"
+    #: Paper-level lineage written by ``ingest.py`` — distinct from the
+    #: authored, equation-level ``DERIVES_FROM`` below.
     DERIVES = "derives"
     DISCRIMINATES_ON = "discriminates_on"
+    # Authored relations between mathematical statements (equations and
+    # sphinx-proof environments). Direction is always specific → general:
+    # the discrete form points at the continuous one it discretizes.
+    DISCRETIZES = "discretizes"
+    DERIVES_FROM = "derives_from"
+    APPROXIMATES = "approximates"
 
 
 @dataclass

--- a/sphinxcontrib/nexus/query.py
+++ b/sphinxcontrib/nexus/query.py
@@ -339,6 +339,18 @@ class RenameResult:
     total_edits: int
 
 
+#: Authored relations between mathematical statements. Stored
+#: specific → general, so following an edge forwards climbs toward the
+#: continuous / exact / parent form.
+STATEMENT_RELATIONS: frozenset[str] = frozenset({
+    "discretizes", "derives_from", "approximates",
+})
+
+#: Node types that carry a mathematical statement — equations and the
+#: sphinx-proof environments (definition, theorem, algorithm, …).
+STATEMENT_TYPES: frozenset[str] = frozenset({"equation", "proof_object"})
+
+
 @dataclass
 class ProvenanceStep:
     """One step in a provenance chain."""
@@ -349,6 +361,20 @@ class ProvenanceStep:
 
 
 @dataclass
+class StatementRelation:
+    """One authored link between two mathematical statements.
+
+    Always read forwards — ``source`` *discretizes* / *derives_from* /
+    *approximates* ``target`` — so no inverse vocabulary is needed and
+    an edge appears once however it was reached.
+    """
+
+    source: NodeResult
+    relation: str
+    target: NodeResult
+
+
+@dataclass
 class ProvenanceResult:
     """Full citation → equation → code traceability chain."""
 
@@ -356,6 +382,11 @@ class ProvenanceResult:
     chain: list[ProvenanceStep]
     equations: list[NodeResult]
     citations: list[str]
+    relations: list[StatementRelation] = field(default_factory=list)
+    """Authored math-to-math structure reachable from this node — the
+    spine a validator walks when asking what a test actually pins down.
+    Empty unless the project declares ``discretizes`` / ``derives-from``
+    / ``approximates`` relations."""
 
 
 @dataclass
@@ -1271,15 +1302,68 @@ class GraphQuery:
     # Feature 1: Provenance Chain
     # ------------------------------------------------------------------
 
+    def _statement_relations(
+        self,
+        roots: list[str],
+        max_depth: int = 4,
+    ) -> list[StatementRelation]:
+        """Collect authored math-to-math edges around statement nodes.
+
+        Walks both directions: outgoing edges climb toward the general
+        form — a discrete equation points at the continuous one it
+        discretizes — and incoming edges descend toward the specific.
+        The question this exists to answer ("what does this test
+        actually pin down?") needs the whole spine, not one hop of it.
+
+        Deduplication is by **edge**, not by node, because the roots are
+        typically every statement on one page: a node-visited set would
+        suppress exactly the links between them, which are the ones
+        worth having. ``max_depth`` bounds hops away from the roots.
+        """
+        relations: list[StatementRelation] = []
+        seen_edges: set[tuple[str, str, str]] = set()
+        visited: set[str] = set()
+        frontier: list[tuple[str, int]] = [(r, 0) for r in roots]
+
+        while frontier:
+            current, depth = frontier.pop(0)
+            if current in visited or depth >= max_depth:
+                continue
+            visited.add(current)
+
+            incident = list(self._g.out_edges(current, data=True))
+            incident += list(self._g.in_edges(current, data=True))
+            for src, tgt, data in incident:
+                relation = data.get("type", "")
+                if relation not in STATEMENT_RELATIONS:
+                    continue
+                key = (src, relation, tgt)
+                if key in seen_edges:
+                    continue
+                seen_edges.add(key)
+                relations.append(StatementRelation(
+                    source=self._node_result(src),
+                    relation=relation,
+                    target=self._node_result(tgt),
+                ))
+                frontier.append((tgt if src == current else src, depth + 1))
+        return relations
+
     def provenance_chain(self, node_id: str) -> ProvenanceResult:
         """Trace citation → equation → code for a symbol.
 
         Given a code symbol, find which doc pages reference it, what
         equations those pages contain, and what citations they use.
-        Given an equation, find the code documented on the same page.
+        Given an equation or proof environment, find the code documented
+        on the same page.
 
         Traverses: code ←DOCUMENTS– doc –CONTAINS→ equations
                                         –CITES→ citations
+
+        Every statement reached is then used as a root for
+        :meth:`_statement_relations`, so any authored ``discretizes`` /
+        ``derives-from`` / ``approximates`` structure comes back in
+        ``relations``.
         """
         equations: list[NodeResult] = []
         citations: list[str] = []
@@ -1310,9 +1394,10 @@ class GraphQuery:
                             edge_type="documented_by", depth=1,
                         ))
 
-        elif node.type == "equation":
+        elif node.type in STATEMENT_TYPES:
             seen_eqs.add(node_id)
-            equations.append(node)
+            if node.type == "equation":
+                equations.append(node)
             for src, _, data in self._g.in_edges(node_id, data=True):
                 src_type = self._g.nodes.get(src, {}).get("type", "")
                 if src_type == "file" and data.get("type") == "contains":
@@ -1333,18 +1418,31 @@ class GraphQuery:
                                         edge_type="implemented_by", depth=2,
                                     ))
 
-        # From doc pages, collect equations and citations
+        # From doc pages, collect statements and citations
+        statements: list[str] = (
+            [node_id] if node.type in STATEMENT_TYPES else []
+        )
         for doc_id in doc_pages:
             for _, tgt, data in self._g.out_edges(doc_id, data=True):
                 tgt_type = self._g.nodes.get(tgt, {}).get("type", "")
                 edge_type = data.get("type", "")
 
-                if tgt_type == "equation" and tgt not in seen_eqs:
+                if tgt_type in STATEMENT_TYPES and tgt not in seen_eqs:
                     seen_eqs.add(tgt)
-                    eq_node = self._node_result(tgt)
-                    equations.append(eq_node)
+                    statements.append(tgt)
+                    stmt_node = self._node_result(tgt)
+                    # ``equations`` is the historical field name and its
+                    # consumers expect equations; proof environments ride
+                    # in the chain and relation walk instead.
+                    if tgt_type == "equation":
+                        equations.append(stmt_node)
                     chain.append(ProvenanceStep(
-                        node=eq_node, edge_type="equation_on_page", depth=2,
+                        node=stmt_node,
+                        edge_type=(
+                            "equation_on_page" if tgt_type == "equation"
+                            else "statement_on_page"
+                        ),
+                        depth=2,
                     ))
 
                 if edge_type == "cites":
@@ -1357,11 +1455,14 @@ class GraphQuery:
                             edge_type="cites", depth=3,
                         ))
 
+        relations = self._statement_relations(statements)
+
         return ProvenanceResult(
             target=node_id,
             chain=chain,
             equations=equations,
             citations=list(set(citations)),
+            relations=relations,
         )
 
     # ------------------------------------------------------------------

--- a/sphinxcontrib/nexus/server.py
+++ b/sphinxcontrib/nexus/server.py
@@ -941,8 +941,15 @@ def provenance_chain(node_id: str) -> str:
     literature citations those equations come from. The complete
     mathematical provenance.
 
+    ``relations`` carries the math-to-math spine where the project
+    declares one: which continuous form a discrete equation
+    ``discretizes``, which parent it ``derives_from``, which exact form
+    it ``approximates`` — plus the inverses, so you can read the chain
+    from either end. Use it to answer what a test actually pins down.
+
     Args:
-        node_id: Node ID of a code symbol or equation.
+        node_id: Node ID of a code symbol, equation, or sphinx-proof
+            environment (``prf:theorem:...``).
     """
     q = _get_query()
     return to_json(to_dict(q.provenance_chain(node_id)))

--- a/sphinxcontrib/nexus/skills/nexus-exploring/reference.md
+++ b/sphinxcontrib/nexus/skills/nexus-exploring/reference.md
@@ -53,7 +53,7 @@ The static graph is *what can run*; a runtime overlay is *what actually ran*. Ca
 ### Code+Doc Fusion
 | Tool | What it answers | Key args |
 |------|----------------|----------|
-| `provenance_chain` | Citation → equation → code chain | `node_id` |
+| `provenance_chain` | Citation → equation → code chain, plus the math-to-math spine in `relations` (what a discrete form discretizes / derives from / approximates) | `node_id` |
 | `verification_coverage` | V&V status map | `status_filter` |
 | `verification_audit` | Complete V&V audit (single call) | — |
 | `verification_gaps` | Untagged tests, unverified equations, missing err catchers | `module`, `level` |
@@ -96,11 +96,12 @@ py:method:orpheus.cp.solver.CPMesh.compute_pinf_group
 py:module:orpheus.sn.solver
 py:tag:geometry
 math:equation:alpha-recursion
+prf:algorithm:transport-sweep
 doc:theory/discrete_ordinates
 std:label:theory-collision-probability
 ```
 
-## Edge Types (13)
+## Edge Types (16)
 
 | Edge | Meaning | Source |
 |------|---------|--------|
@@ -117,6 +118,9 @@ std:label:theory-collision-probability
 | `tests` | Test function → tested function | AST |
 | `derives` | Derivation → equation | AST |
 | `discriminates_on` | Function → tag it branches on (`if x == "..."`, `match`) | AST |
+| `discretizes` | Discrete statement → the continuous one it discretizes | Directive |
+| `derives_from` | Specialization → the parent it was reduced from | Directive |
+| `approximates` | Closure/truncation → the exact form it stands in for | Directive |
 
 ## graph_query Pattern Syntax
 

--- a/sphinxcontrib/nexus/visualize.py
+++ b/sphinxcontrib/nexus/visualize.py
@@ -22,6 +22,7 @@ _NODE_COLORS = {
     "method": "#27AE60", "class": "#E74C3C", "module": "#F39C12",
     "equation": "#9B59B6", "term": "#1ABC9C", "attribute": "#95A5A6",
     "data": "#95A5A6", "exception": "#E74C3C", "type": "#3498DB",
+    "proof_object": "#8E44AD",
     "external": "#BDC3C7", "unresolved": "#555", "unknown": "#555",
 }
 
@@ -30,6 +31,10 @@ _EDGE_COLORS = {
     "contains": "#555", "documents": "#4A90D9", "references": "#7B68EE",
     "implements": "#9B59B6", "type_uses": "#1ABC9C", "equation_ref": "#9B59B6",
     "cites": "#E67E22",
+    # The math-to-math relations share the equation hue: on a rendered
+    # graph they read as one spine rather than three unrelated colours.
+    "discretizes": "#9B59B6", "derives_from": "#9B59B6",
+    "approximates": "#9B59B6",
 }
 
 # The entire visualizer is a single self-contained HTML file.

--- a/tests/roots/test-proof-relations-bad/conf.py
+++ b/tests/roots/test-proof-relations-bad/conf.py
@@ -1,0 +1,3 @@
+extensions = ["sphinxcontrib.nexus"]
+master_doc = "index"
+exclude_patterns = ["_build"]

--- a/tests/roots/test-proof-relations-bad/index.rst
+++ b/tests/roots/test-proof-relations-bad/index.rst
@@ -1,0 +1,20 @@
+Misused Relations
+=================
+
+Nothing labelled precedes this, and no ``:label:`` names a source:
+
+.. discretizes:: some-continuous-form
+
+.. math::
+   :label: eq-a
+
+   x = 1
+
+Binds to ``eq-a`` above, which is also the target:
+
+.. derives-from:: eq-a
+
+A target that does not exist anywhere in the project:
+
+.. approximates:: never-written
+   :label: eq-a

--- a/tests/roots/test-proof-relations/conf.py
+++ b/tests/roots/test-proof-relations/conf.py
@@ -1,0 +1,3 @@
+extensions = ["sphinx_proof", "sphinxcontrib.nexus"]
+master_doc = "index"
+exclude_patterns = ["_build"]

--- a/tests/roots/test-proof-relations/index.rst
+++ b/tests/roots/test-proof-relations/index.rst
@@ -1,0 +1,79 @@
+Discrete Ordinates
+==================
+
+The continuous transport equation:
+
+.. math::
+   :label: transport-continuous
+
+   \Omega \cdot \nabla \psi + \Sigma_t \psi = q
+
+Specializing to a discrete angular quadrature:
+
+.. math::
+   :label: transport-sn
+
+   \Omega_n \cdot \nabla \psi_n + \Sigma_t \psi_n = q_n
+
+.. derives-from:: transport-continuous
+
+The diamond-difference closure, with no explicit ``:label:`` on the
+directive so it binds to the equation directly above it:
+
+.. math::
+   :label: dd-closure
+
+   \psi_c = \frac{1}{2} (\psi_L + \psi_R)
+
+.. discretizes:: transport-sn
+
+   The cell-centred flux is the arithmetic mean of the two faces.
+
+A closure that stands in for the exact scattering integral, declared out
+of order via an explicit ``:label:``:
+
+.. math::
+   :label: p1-closure
+
+   \Sigma_s \phi_1 \approx \frac{1}{3} \nabla \phi_0
+
+.. approximates:: transport-continuous
+   :label: p1-closure
+
+Typed environments
+------------------
+
+.. prf:definition:: Angular flux
+   :label: def-angular-flux
+
+   The angular flux :math:`\psi(\mathbf{r}, \Omega, E)` is the number of
+   particles crossing unit area per unit solid angle per unit energy.
+
+.. prf:theorem:: Transport balance
+   :label: thm-balance
+
+   Given :prf:ref:`def-angular-flux`, the balance in
+   :eq:`transport-continuous` holds over any control volume.
+
+.. derives-from:: def-angular-flux
+   :label: thm-balance
+
+.. prf:algorithm:: Transport sweep
+   :label: alg-sweep
+
+   Order the cells along :math:`\Omega_n` and solve each in turn.
+
+.. prf:remark::
+
+   An unlabelled environment. sphinx-proof gives it a serial-numbered
+   synthetic label, and nothing can reference it.
+
+Implementation
+--------------
+
+.. py:function:: solver.sweep(psi, sigma_t)
+
+   Run one transport sweep.
+
+.. implements:: dd-closure
+   :by: solver.sweep

--- a/tests/test_proof_relations.py
+++ b/tests/test_proof_relations.py
@@ -1,0 +1,470 @@
+"""Statement-to-statement relations (#19) and sphinx-proof nodes (#21).
+
+Both features only exist as a consequence of a real Sphinx build: the
+relation directives run at ``doctree-read`` and replay against a graph
+that doesn't exist yet when they fire, and the ``prf`` domain publishes
+nothing through ``Domain.get_objects()`` — the environments live on
+``env.proof_list`` and in the doctree. A hand-built fixture would test
+our idea of sphinx-proof rather than sphinx-proof, so the module builds
+``tests/roots/test-proof-relations`` once with the real extension.
+
+The pure helpers get direct unit tests below the build-backed ones.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import networkx as nx
+import pytest
+from docutils import nodes as docutils_nodes
+from docutils.frontend import get_default_settings
+from docutils.parsers.rst import Parser as RSTParser
+from docutils.utils import new_document
+
+from sphinxcontrib.nexus._mappings import resolve_proof_id, resolve_target_id
+from sphinxcontrib.nexus.directives import (
+    EQUATION_RELATIONS,
+    _apply_relation,
+    _nearest_preceding_label,
+    _resolve_statement_id,
+)
+from sphinxcontrib.nexus.export import load_sqlite
+from sphinxcontrib.nexus.extractors import (
+    _is_auto_proof_label,
+    _proof_title,
+)
+from sphinxcontrib.nexus.query import GraphQuery
+
+ROOT = Path(__file__).parent / "roots" / "test-proof-relations"
+
+pytest.importorskip(
+    "sphinx_proof",
+    reason="sphinx-proof drives the prf half of this module",
+)
+
+
+@pytest.fixture(scope="module")
+def built(tmp_path_factory):
+    """The knowledge graph from one real build of the fixture root."""
+    out = tmp_path_factory.mktemp("proof-relations")
+    proc = subprocess.run(
+        [sys.executable, "-m", "sphinx", "-q", "-E", str(ROOT), str(out)],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+
+    # A directive that can't bind its source, or a prf label that doesn't
+    # resolve, warns and is dropped — the edge would then be missing for
+    # a reason no assertion below would name. Checked against the
+    # fixture's own labels rather than with ``-W``, so an unrelated
+    # upstream deprecation doesn't redden this module.
+    noise = [
+        line for line in (proc.stdout + proc.stderr).splitlines()
+        if "WARNING" in line and "index.rst" in line
+    ]
+    assert not noise, noise
+
+    db = out / "_nexus" / "graph.db"
+    assert db.exists(), f"no graph at {db}"
+    return load_sqlite(db)
+
+
+@pytest.fixture(scope="module")
+def graph(built):
+    return built.nxgraph
+
+
+@pytest.fixture(scope="module")
+def query(built):
+    return GraphQuery(built)
+
+
+def _relation_edges(graph: nx.MultiDiGraph) -> set[tuple[str, str, str]]:
+    return {
+        (src, data.get("type", ""), tgt)
+        for src, tgt, data in graph.edges(data=True)
+        if data.get("type") in EQUATION_RELATIONS.values()
+    }
+
+
+# ---------------------------------------------------------------------------
+# #19 — equation → equation relations
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_label_binds_the_named_source(graph):
+    """``:label:`` names the source no matter where the directive sits."""
+    assert (
+        "math:equation:p1-closure",
+        "approximates",
+        "math:equation:transport-continuous",
+    ) in _relation_edges(graph)
+
+
+def test_omitted_label_binds_the_preceding_equation(graph):
+    """The ergonomic case: written under the equation it describes.
+
+    ``.. discretizes:: transport-sn`` in the fixture carries no
+    ``:label:`` and sits directly beneath ``dd-closure``.
+    """
+    assert (
+        "math:equation:dd-closure",
+        "discretizes",
+        "math:equation:transport-sn",
+    ) in _relation_edges(graph)
+
+
+def test_all_three_relations_are_registered(graph):
+    """Each directive name must reach the graph as its own edge type."""
+    found = {relation for _, relation, _ in _relation_edges(graph)}
+    assert found == {"discretizes", "derives_from", "approximates"}
+
+
+def test_relations_carry_directive_provenance(graph):
+    for src, tgt, data in graph.edges(data=True):
+        if data.get("type") in EQUATION_RELATIONS.values():
+            assert data.get("source") == "directive", (src, tgt)
+            assert data.get("confidence") == 1.0
+
+
+def test_relation_between_proof_environments(graph):
+    """Both ends may be proof objects — same syntax, no new directive."""
+    assert (
+        "prf:theorem:thm-balance",
+        "derives_from",
+        "prf:definition:def-angular-flux",
+    ) in _relation_edges(graph)
+
+
+def test_equations_are_no_longer_leaves(graph):
+    """The point of #19: the math has structure of its own."""
+    out = [
+        d.get("type")
+        for _, _, d in graph.out_edges("math:equation:transport-sn", data=True)
+    ]
+    assert "derives_from" in out
+
+
+# ---------------------------------------------------------------------------
+# #21 — sphinx-proof environments as nodes
+# ---------------------------------------------------------------------------
+
+
+def test_labelled_environments_become_nodes(graph):
+    for node_id in (
+        "prf:definition:def-angular-flux",
+        "prf:theorem:thm-balance",
+        "prf:algorithm:alg-sweep",
+    ):
+        assert node_id in graph.nodes, node_id
+        assert graph.nodes[node_id]["type"] == "proof_object"
+
+
+def test_environment_kind_is_queryable(graph):
+    """One node type, with the environment kept as an attribute — an
+    ``algorithm`` has to be findable without parsing node ids."""
+    kinds = {
+        attrs.get("prf_type")
+        for _, attrs in graph.nodes(data=True)
+        if attrs.get("type") == "proof_object"
+    }
+    assert kinds == {"definition", "theorem", "algorithm"}
+
+
+def test_unlabelled_environment_is_not_a_node(graph):
+    """sphinx-proof gives it a serial-numbered synthetic label that
+    renumbers on every edit above it, and nothing can reference it."""
+    synthetic = [
+        n for n in graph.nodes
+        if isinstance(n, str) and n.startswith("prf:remark:")
+    ]
+    assert synthetic == []
+
+
+def test_environments_are_contained_by_their_page(graph):
+    assert graph.has_edge("doc:index", "prf:theorem:thm-balance")
+
+
+def test_title_and_statement_come_from_the_doctree(graph):
+    """``env.proof_list`` records where a theorem lives, not what it
+    says; the prose only exists in the doctree."""
+    attrs = graph.nodes["prf:definition:def-angular-flux"]
+    assert attrs["display_name"] == "Angular flux"
+    assert "number of particles" in attrs["statement"]
+
+
+def test_prf_ref_resolves_instead_of_going_dead(graph):
+    """A ``:prf:ref:`` names a label but not an environment. If that
+    doesn't resolve, every cross-reference in a sphinx-proof project
+    becomes a false dead reference."""
+    assert graph.has_edge("doc:index", "prf:definition:def-angular-flux")
+    unresolved = [
+        n for n, a in graph.nodes(data=True)
+        if a.get("type") in ("unresolved", "external")
+    ]
+    assert unresolved == []
+
+
+def test_no_dead_references_reported(query):
+    """The whole fixture is internally consistent; anything reported
+    here would be a false positive from the new node/edge types."""
+    result = query.dead_references()
+    assert result.total_dead == 0, [d.target for d in result.dead]
+
+
+# ---------------------------------------------------------------------------
+# Consumption — the edges have to reach a query to have earned their place
+# ---------------------------------------------------------------------------
+
+
+def test_provenance_from_an_equation_returns_the_spine(query):
+    result = query.provenance_chain("math:equation:dd-closure")
+    hops = {(r.source.name, r.relation, r.target.name) for r in result.relations}
+    assert ("dd-closure", "discretizes", "transport-sn") in hops
+    # Transitive: dd-closure → transport-sn → transport-continuous.
+    assert ("transport-sn", "derives_from", "transport-continuous") in hops
+
+
+def test_provenance_from_code_reaches_the_spine(query):
+    """The motivating query: this test verifies the discrete form, which
+    discretizes this continuous one."""
+    result = query.provenance_chain("py:function:solver.sweep")
+    hops = {(r.source.name, r.relation, r.target.name) for r in result.relations}
+    assert ("dd-closure", "discretizes", "transport-sn") in hops
+
+
+def test_each_relation_is_reported_once(query):
+    """Roots are typically every statement on one page, so both ends of
+    a link are usually roots. Dedup is by edge, so the link survives —
+    and appears exactly once, not once per direction."""
+    result = query.provenance_chain("math:equation:dd-closure")
+    keys = [(r.source.id, r.relation, r.target.id) for r in result.relations]
+    assert len(keys) == len(set(keys))
+
+
+def test_provenance_accepts_a_proof_object(query):
+    result = query.provenance_chain("prf:theorem:thm-balance")
+    assert result.chain[0].node.id == "prf:theorem:thm-balance"
+    assert any(
+        r.target.id == "prf:definition:def-angular-flux" for r in result.relations
+    )
+
+
+def test_graph_query_reaches_the_new_types(query):
+    """The generic pattern language is the escape hatch for questions no
+    dedicated tool covers; new types must be addressable there."""
+    hits = query.graph_query("equation -discretizes-> equation")
+    assert [h["source"]["id"] for h in hits] == ["math:equation:dd-closure"]
+    prf = query.graph_query("proof_object -derives_from-> proof_object")
+    assert [h["target"]["id"] for h in prf] == ["prf:definition:def-angular-flux"]
+
+
+def test_keyword_search_finds_an_environment_by_title(query):
+    """The title is the human handle — ``def-angular-flux`` is not what
+    anyone types."""
+    assert [n.id for n in query.query("angular flux")] == [
+        "prf:definition:def-angular-flux"
+    ]
+
+
+def test_proof_objects_do_not_pollute_the_equations_field(query):
+    """``equations`` is a named contract; proof objects ride in the
+    chain and relations instead."""
+    result = query.provenance_chain("py:function:solver.sweep")
+    assert all(e.id.startswith("math:equation:") for e in result.equations)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_auto_proof_label_detection():
+    assert _is_auto_proof_label("remark-3", "remark")
+    assert _is_auto_proof_label("theorem-12", "theorem")
+    assert not _is_auto_proof_label("thm-balance", "theorem")
+    # A hand-written label that merely starts with the type name.
+    assert not _is_auto_proof_label("theorem-of-the-mean", "theorem")
+
+
+def test_proof_title_unwraps_the_render_format():
+    assert _proof_title("(Angular flux)") == "Angular flux"
+    assert _proof_title("Angular flux") == "Angular flux"
+    assert _proof_title("") == ""
+    # Not a wrapper — leave it alone rather than mangle the title.
+    assert _proof_title("(a) and (b)") == "(a) and (b)"
+
+
+def test_resolve_proof_id_tries_every_environment():
+    g = nx.MultiDiGraph()
+    g.add_node("prf:algorithm:sweep")
+    assert resolve_proof_id(g, "sweep") == "prf:algorithm:sweep"
+    assert resolve_proof_id(g, "nope") is None
+
+
+def test_resolve_proof_id_falls_back_to_a_scan():
+    """An environment sphinx-proof adds after PRF_OBJECT_TYPES was
+    written must still resolve, or its references read as dead."""
+    g = nx.MultiDiGraph()
+    g.add_node("prf:brandnewtype:thing")
+    assert resolve_proof_id(g, "thing") == "prf:brandnewtype:thing"
+
+
+def test_prf_xrefs_route_through_the_proof_resolver():
+    g = nx.MultiDiGraph()
+    g.add_node("prf:theorem:balance")
+    assert resolve_target_id(g, None, "prf", "ref", "balance") == (
+        "prf:theorem:balance"
+    )
+
+
+def test_statement_id_prefers_an_equation():
+    g = nx.MultiDiGraph()
+    g.add_node("math:equation:x")
+    g.add_node("prf:theorem:y")
+    assert _resolve_statement_id("x", g) == "math:equation:x"
+    assert _resolve_statement_id("y", g) == "prf:theorem:y"
+    assert _resolve_statement_id("z", g) is None
+
+
+# ---------------------------------------------------------------------------
+# Misuse must be loud, and must not break the build
+# ---------------------------------------------------------------------------
+
+
+def test_misuse_warns_without_failing_the_build(tmp_path):
+    """Three ways to get a relation wrong, each one reported.
+
+    A directive that silently declares nothing is the failure mode this
+    whole feature exists to prevent, so every drop is a warning — but
+    prose mistakes must never take a docs build down with them.
+    """
+    proc = subprocess.run(
+        [
+            sys.executable, "-m", "sphinx", "-q", "-E",
+            str(Path(__file__).parent / "roots" / "test-proof-relations-bad"),
+            str(tmp_path / "out"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    output = proc.stdout + proc.stderr
+
+    # No source to bind to — caught at parse time.
+    assert "needs a ':label:' option" in output
+    # Source and target are the same statement.
+    assert "relates a statement to itself" in output
+    # Target doesn't exist — only knowable at replay, against the graph.
+    assert "target statement 'never-written' not found" in output
+
+
+class _FakeState:
+    """Just enough of a docutils state to carry a document."""
+
+    def __init__(self, document):
+        self.document = document
+
+
+def _empty_document():
+    return new_document("<test>", get_default_settings(RSTParser()))
+
+
+def _document_with(*labelled):
+    """A document holding the given (node, label) pairs in order."""
+    doc = _empty_document()
+    for node, label in labelled:
+        node["label"] = label
+        doc += node
+    return doc
+
+
+def _proof_node(realtype):
+    node = docutils_nodes.Element()
+    node["realtype"] = realtype
+    return node
+
+
+def test_nearest_preceding_label_takes_the_last_math_block():
+    doc = _document_with(
+        (docutils_nodes.math_block(), "first"),
+        (docutils_nodes.math_block(), "second"),
+    )
+    assert _nearest_preceding_label(_FakeState(doc)) == "second"
+
+
+def test_nearest_preceding_label_ignores_unlabelled_math():
+    doc = _document_with((docutils_nodes.math_block(), "only"))
+    doc += docutils_nodes.math_block()  # no :label:, not referenceable
+    assert _nearest_preceding_label(_FakeState(doc)) == "only"
+
+
+def test_nearest_preceding_label_accepts_a_proof_environment():
+    doc = _document_with((_proof_node("theorem"), "thm-balance"))
+    assert _nearest_preceding_label(_FakeState(doc)) == "thm-balance"
+
+
+def test_nearest_preceding_label_skips_synthetic_proof_labels():
+    """Binding to an unlabelled remark's serial label would name
+    something the graph never holds — a confusing "not found" at
+    replay instead of the honest "needs a :label:" at parse."""
+    doc = _document_with(
+        (docutils_nodes.math_block(), "dd-closure"),
+        (_proof_node("remark"), "remark-7"),
+    )
+    assert _nearest_preceding_label(_FakeState(doc)) == "dd-closure"
+
+
+def test_nearest_preceding_label_none_when_nothing_precedes():
+    assert _nearest_preceding_label(_FakeState(_empty_document())) is None
+
+
+def _relation_graph() -> nx.MultiDiGraph:
+    g = nx.MultiDiGraph()
+    g.add_node("math:equation:a")
+    g.add_node("math:equation:b")
+    return g
+
+
+def test_apply_relation_writes_one_edge():
+    g = _relation_graph()
+    entry = {"kind": "discretizes", "from_label": "a", "to_label": "b"}
+    assert _apply_relation(entry, g, "index:1") == 1
+    assert g.has_edge("math:equation:a", "math:equation:b")
+
+
+def test_apply_relation_is_idempotent():
+    """Directive payloads persist across incremental builds and replay
+    against a graph that may already hold the edge."""
+    g = _relation_graph()
+    entry = {"kind": "discretizes", "from_label": "a", "to_label": "b"}
+    assert _apply_relation(entry, g, "index:1") == 1
+    assert _apply_relation(entry, g, "index:1") == 0
+    assert g.number_of_edges("math:equation:a", "math:equation:b") == 1
+
+
+def test_apply_relation_skips_a_missing_end():
+    g = _relation_graph()
+    assert _apply_relation(
+        {"kind": "discretizes", "from_label": "a", "to_label": "gone"},
+        g, "index:1",
+    ) == 0
+    assert _apply_relation(
+        {"kind": "discretizes", "from_label": "gone", "to_label": "b"},
+        g, "index:1",
+    ) == 0
+    assert g.number_of_edges() == 0
+
+
+def test_distinct_relations_between_the_same_pair_coexist():
+    """Two relations are two facts; the idempotence guard is per type."""
+    g = _relation_graph()
+    for kind in ("discretizes", "approximates"):
+        assert _apply_relation(
+            {"kind": kind, "from_label": "a", "to_label": "b"}, g, "index:1",
+        ) == 1
+    assert g.number_of_edges("math:equation:a", "math:equation:b") == 2


### PR DESCRIPTION
Closes #19. Closes #21.

Equations were graph leaves. The graph knew which code implemented an equation and which test verified it, but nothing about how the equations relate to each other — so `provenance_chain` returned a flat list where a validator wants a spine.

## Statement relations (#19)

Three directives declare the structure of the math itself:

```rst
.. math::
   :label: sn-dd-closure

   \psi_c = \tfrac{1}{2}(\psi_L + \psi_R)

.. discretizes:: sn-transport-continuous
```

| Directive | Declares |
|-----------|----------|
| `discretizes` | This discrete form discretizes that continuous one |
| `derives-from` | This specialization derives from that parent |
| `approximates` | This closure or truncation approximates that exact form |

Each names its **target** as the argument. The **source** comes from `:label:` or — when omitted, as above — from the nearest preceding labelled statement, which is where these get written in practice. New `EdgeType` values `DISCRETIZES` / `DERIVES_FROM` / `APPROXIMATES`, tagged `source="directive"` and surviving incremental builds through the existing pending queue.

Misuse warns and is dropped, never breaking the build: no bindable source, a statement related to itself, or a target that doesn't exist.

## sphinx-proof environments (#21)

Every **labelled** `prf:` environment becomes a `proof_object` node carrying its title, its statement text, and its kind in `metadata["prf_type"]`.

The `prf` domain exposes neither `object_types` nor `get_objects()` — everything lives on `env.proof_list` — so the generic domain walk sees nothing and these are read directly, then enriched from the doctree (`proof_list` records where a theorem lives, not what it says). `:prf:ref:` targets now resolve to those nodes, which matters more than it sounds: without it, every cross-reference in a sphinx-proof project would surface as a **false dead reference**.

One node type rather than fifteen — the kind is an attribute and the node id (`prf:theorem:thm-balance`) already carries it. Unlabelled environments are skipped: sphinx-proof gives them a serial-numbered synthetic label that renumbers whenever anything above them moves, and nothing can reference them.

Both ends of a relation may be an equation *or* a proof environment, so *Theorem 3.4 derives-from Definition 3.2* needs no new syntax.

## Consumption

`provenance_chain` returns a `relations` list of `source ─relation→ target` triples reachable from the queried node — from a code symbol, an equation, or a proof environment. Dedup is by **edge**, not node: the roots are typically every statement on one page, so a node-visited set would suppress exactly the links worth having. `graph_query` and keyword search reach the new types with no changes.

## Validation

Tested against a **real sphinx-proof build** (`tests/roots/test-proof-relations`) rather than a fixture guess — the whole question is what the upstream extension actually publishes. `sphinx-proof` is now a test-only dependency. 36 new tests, 629 total, pyright clean.

Validated on ORPHEUS (which uses neither feature yet, so this is a pure regression check): **24,873 nodes / 214,287 edges, node sets and type histograms identical** to the released build, same 21 dead references, same provenance chains.

## Notes

- Additive only — no SQLite `SCHEMA_VERSION` bump, per the policy in the issue.
- `metadata["statement"]` is not in the FTS index (it lives in the metadata blob, and a column would force a schema bump). The title *is* searchable via `display_name`. Full-text/embedding use is #1's business.
- #21's consumer-driven trigger has still not fired — ORPHEUS has no `sphinx_proof` in `conf.py`. Building it now against the real extension means the extractor is verified against genuine upstream behaviour rather than a guess, so ORPHEUS can adopt it whenever it's ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PTrKtfrCB3znVo5fhLHRe