### PR TITLE
fix(resolve): rank suffix-match candidates instead of taking the first (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,26 @@ Tested against a real `sphinx-proof` build (`tests/roots/test-proof-relations`)
 rather than a fixture guess, since the whole point is what the upstream
 extension actually publishes. `sphinx-proof` is now a test-only dependency.
 
+### Fixed — reference resolution no longer prefers a tombstone (#36)
+
+`resolve_target_id` took the *first* node whose name ended in the reftarget, so
+a placeholder minted from a retired import path competed on equal footing with
+a real definition and won on graph-insertion order. On ORPHEUS a bare
+``:func:`compute_G_bc``` bound to the phantom
+`orpheus.derivations.peierls_geometry.compute_G_bc` instead of the live
+`...peierls_nystrom.geometry.compute_G_bc` — and `dead_references` then reported
+the phantom the resolver had just invented, on a surface agents are told to
+trust.
+
+Candidates are now ranked: a real definition beats a placeholder, then obj_type
+order, then the shortest qualified name, then the id — so resolution no longer
+depends on build order. The exact-match fast path carried the same defect one
+level up (an exact hit on a bare tombstone short-circuited before ranking ran);
+it is now held as a fallback and used only when nothing real matches anywhere.
+
+Measured on a real ORPHEUS rebuild: dead references 14 → 7, with zero new
+findings and no change in kind to the rest of the graph.
+
 ## 0.16.1 — 2026-08-09
 
 ### Fixed

--- a/sphinxcontrib/nexus/_mappings.py
+++ b/sphinxcontrib/nexus/_mappings.py
@@ -81,6 +81,14 @@ PRF_OBJECT_TYPES: tuple[str, ...] = (
     "theorem",
 )
 
+# Node types that stand in for a symbol nexus could not place. They are
+# minted so a reference has *something* to point at; none of them is a
+# definition. When a suffix match has to choose between candidates, a
+# real definition always outranks a placeholder.
+_PLACEHOLDER_TYPES: frozenset[str] = frozenset(
+    {NodeType.UNRESOLVED.value, NodeType.EXTERNAL.value}
+)
+
 # Map pending_xref reftype to EdgeType.
 REFTYPE_EDGE_MAP: dict[str, EdgeType] = {
     "ref": EdgeType.REFERENCES,
@@ -162,20 +170,56 @@ def resolve_target_id(
             if reftype in obj_type.roles and obj_type_name not in candidate_objtypes:
                 candidate_objtypes.append(obj_type_name)
 
-    # Try exact match first
+    # Try exact match first — the common case, and an O(1) lookup
+    # rather than a scan of the whole graph.
+    #
+    # A placeholder does NOT short-circuit. ``py:function:compute_G_bc``
+    # is a tombstone: it exists only because some bare role could not be
+    # placed, so binding a live reference to it manufactures a dead
+    # reference out of a symbol that does exist. Hold it as a fallback
+    # and let the suffix scan look for a real definition first.
+    exact_placeholder: str | None = None
     for objtype in candidate_objtypes:
         nid = f"{refdomain}:{objtype}:{reftarget}"
         if nid in nxgraph:
-            return nid
+            if nxgraph.nodes[nid].get("type", "") not in _PLACEHOLDER_TYPES:
+                return nid
+            if exact_placeholder is None:
+                exact_placeholder = nid
 
-    # Suffix match: "CPMesh" matches "collision_probability.CPMesh"
+    # Suffix match: "CPMesh" matches "collision_probability.CPMesh".
+    #
+    # Several nodes routinely share a suffix — a live definition and a
+    # placeholder minted from some retired import path can both end in
+    # ``.compute_G_bc``. Returning whichever the graph happens to yield
+    # first makes resolution depend on insertion order, and picking the
+    # placeholder invents a dead reference out of a live symbol. So rank
+    # every candidate instead: a real definition beats a placeholder,
+    # then earlier obj_types win, then the shortest qualified name, then
+    # the id itself so the result is stable across builds.
     suffix = f".{reftarget}"
-    for objtype in candidate_objtypes:
+    best: tuple[int, int, int, str] | None = None
+    for rank_objtype, objtype in enumerate(candidate_objtypes):
         prefix = f"{refdomain}:{objtype}:"
         for node_id in nxgraph:
-            if isinstance(node_id, str) and node_id.startswith(prefix):
-                name = node_id[len(prefix):]
-                if name.endswith(suffix) or name == reftarget:
-                    return node_id
+            if not isinstance(node_id, str) or not node_id.startswith(prefix):
+                continue
+            name = node_id[len(prefix):]
+            if not (name.endswith(suffix) or name == reftarget):
+                continue
+            node_type = nxgraph.nodes[node_id].get("type", "")
+            rank_real = 1 if node_type in _PLACEHOLDER_TYPES else 0
+            key = (rank_real, rank_objtype, len(name), node_id)
+            if best is None or key < best:
+                best = key
 
-    return None
+    if best is not None and best[0] == 0:
+        return best[3]
+
+    # Nothing real matched anywhere. An exact-name placeholder is the
+    # better answer than a suffix-matched one — equally uninformative,
+    # but at least it is the name the author actually wrote, and reusing
+    # it avoids minting a second phantom for the same symbol.
+    if exact_placeholder is not None:
+        return exact_placeholder
+    return best[3] if best is not None else None

--- a/tests/test_dead_references.py
+++ b/tests/test_dead_references.py
@@ -578,3 +578,152 @@ def test_cli_exit_code_gates_ci(tmp_path, capsys):
     ))
     capsys.readouterr()
     assert code == 1
+
+
+# ---------------------------------------------------------------------------
+# Suffix-match ranking (issue #36)
+# ---------------------------------------------------------------------------
+#
+# The shape that produced a 46 % false-positive rate on ORPHEUS: a
+# retired module path survives in prototype/archive source, so the AST
+# pass mints ``py:function:orpheus.derivations.peierls_geometry.
+# compute_G_bc`` as a placeholder — while the live definition sits at
+# ``...peierls_nystrom.geometry.compute_G_bc``. A bare ``:func:`` role
+# suffix-matches BOTH. Picking the placeholder turns a live symbol into
+# a reported dead reference; the graph invents the drift it then flags.
+
+
+class _ObjType:
+    def __init__(self, *roles: str) -> None:
+        self.roles = roles
+
+
+class _StubPyDomain:
+    """The slice of ``PythonDomain`` the resolver reads.
+
+    ``resolve_target_id`` widens a reftype ("func") into candidate
+    obj_types ("function") through ``domain.object_types``. Passing
+    ``None`` would leave only the literal reftype, and ``py:func:``
+    matches no node — so the stub is what makes these tests exercise
+    the suffix path at all.
+    """
+
+    object_types = {
+        "function": _ObjType("func", "obj"),
+        "class": _ObjType("class", "exc", "obj"),
+        "method": _ObjType("meth", "obj"),
+    }
+
+
+def _ranking_graph() -> KnowledgeGraph:
+    kg = KnowledgeGraph()
+    _node(kg, "py:function:pkg.retired.compute_G_bc", NodeType.UNRESOLVED,
+          "pkg.retired.compute_G_bc")
+    _node(kg, "py:function:pkg.live.geometry.compute_G_bc", NodeType.FUNCTION,
+          "pkg.live.geometry.compute_G_bc")
+    return kg
+
+
+def test_suffix_match_prefers_definition_over_placeholder():
+    from sphinxcontrib.nexus._mappings import resolve_target_id
+
+    resolved = resolve_target_id(
+        _ranking_graph().nxgraph, _StubPyDomain(), "py", "func", "compute_G_bc",
+    )
+    assert resolved == "py:function:pkg.live.geometry.compute_G_bc"
+
+
+def test_suffix_match_ranking_ignores_insertion_order():
+    """The placeholder inserted FIRST must still lose.
+
+    The pre-fix resolver returned whichever candidate ``nxgraph``
+    yielded first, so the answer rode on build order.
+    """
+    from sphinxcontrib.nexus._mappings import resolve_target_id
+
+    kg = KnowledgeGraph()
+    _node(kg, "py:function:a.retired.thing", NodeType.UNRESOLVED,
+          "a.retired.thing")
+    _node(kg, "py:function:z.live.thing", NodeType.FUNCTION, "z.live.thing")
+    assert resolve_target_id(kg.nxgraph, _StubPyDomain(), "py", "func", "thing") == (
+        "py:function:z.live.thing"
+    )
+
+
+def test_suffix_match_still_resolves_when_only_placeholder_exists():
+    """Ranking must not become a filter.
+
+    A placeholder is still the best available answer when nothing real
+    shares the suffix — dropping to ``None`` here would mint a SECOND
+    phantom rather than reuse the one already standing.
+    """
+    from sphinxcontrib.nexus._mappings import resolve_target_id
+
+    kg = KnowledgeGraph()
+    _node(kg, "py:function:pkg.retired.only", NodeType.UNRESOLVED,
+          "pkg.retired.only")
+    assert resolve_target_id(kg.nxgraph, _StubPyDomain(), "py", "func", "only") == (
+        "py:function:pkg.retired.only"
+    )
+
+
+def test_suffix_match_breaks_ties_on_shortest_path():
+    """Two live definitions: deterministic, and the shallower wins."""
+    from sphinxcontrib.nexus._mappings import resolve_target_id
+
+    kg = KnowledgeGraph()
+    _node(kg, "py:function:pkg.deep.nested.here.solve", NodeType.FUNCTION,
+          "pkg.deep.nested.here.solve")
+    _node(kg, "py:function:pkg.solve", NodeType.FUNCTION, "pkg.solve")
+    assert resolve_target_id(kg.nxgraph, _StubPyDomain(), "py", "func", "solve") == (
+        "py:function:pkg.solve"
+    )
+
+
+def test_exact_placeholder_does_not_shadow_real_definition():
+    """The bare tombstone must not win by being exact.
+
+    On ORPHEUS a bare ``:func:`compute_G_bc`` had minted
+    ``py:function:compute_G_bc``; the exact-match lookup returned it
+    before suffix ranking ever ran, so the live definition was
+    unreachable and the reference reported dead.
+    """
+    from sphinxcontrib.nexus._mappings import resolve_target_id
+
+    kg = KnowledgeGraph()
+    _node(kg, "py:function:compute_G_bc", NodeType.UNRESOLVED, "compute_G_bc")
+    _node(kg, "py:function:pkg.live.geometry.compute_G_bc", NodeType.FUNCTION,
+          "pkg.live.geometry.compute_G_bc")
+    assert resolve_target_id(
+        kg.nxgraph, _StubPyDomain(), "py", "func", "compute_G_bc",
+    ) == "py:function:pkg.live.geometry.compute_G_bc"
+
+
+def test_exact_placeholder_wins_over_suffix_placeholder():
+    """With nothing real anywhere, prefer the name as written.
+
+    Reusing the exact tombstone keeps one phantom per missing symbol
+    instead of splitting references across two.
+    """
+    from sphinxcontrib.nexus._mappings import resolve_target_id
+
+    kg = KnowledgeGraph()
+    _node(kg, "py:function:widget", NodeType.UNRESOLVED, "widget")
+    _node(kg, "py:function:pkg.retired.widget", NodeType.UNRESOLVED,
+          "pkg.retired.widget")
+    assert resolve_target_id(
+        kg.nxgraph, _StubPyDomain(), "py", "func", "widget",
+    ) == "py:function:widget"
+
+
+def test_exact_real_match_still_short_circuits():
+    """The fast path survives: an exact hit on a real definition wins
+    outright, without paying for a graph scan."""
+    from sphinxcontrib.nexus._mappings import resolve_target_id
+
+    kg = KnowledgeGraph()
+    _node(kg, "py:function:pkg.mod.solve", NodeType.FUNCTION, "pkg.mod.solve")
+    _node(kg, "py:function:other.solve", NodeType.FUNCTION, "other.solve")
+    assert resolve_target_id(
+        kg.nxgraph, _StubPyDomain(), "py", "func", "pkg.mod.solve",
+    ) == "py:function:pkg.mod.solve"


### PR DESCRIPTION
Closes #36 — though not as filed. The issue hypothesised stale accumulation in `graph.db`; that turned out to be refutable ([full refutation](https://github.com/deOliveira-R/sphinxcontrib-nexus/issues/36#issuecomment-5239725177)), and the real defect was in reference resolution.

## The bug

`resolve_target_id` returned the **first** node whose name ended in the reftarget. No ranking — so a placeholder minted from a retired import path competed on equal footing with a real definition and won on graph-insertion order:

```
py:function:orpheus.derivations.continuous.peierls_nystrom.geometry.compute_G_bc   type=function     ← live
py:function:orpheus.derivations.peierls_geometry.compute_G_bc                      type=unresolved   ← placeholder
```

A bare ``:func:`compute_G_bc``` on a theory page bound to the phantom, and `dead_references` then reported the phantom the resolver had just invented — on a surface wired into SessionStart and one agents are told to trust.

## The fix

Rank every candidate instead of taking the first: real definition over placeholder, then obj_type order, then shortest qualified name, then id — so the answer no longer rides on build order.

The exact-match fast path carried the same defect one level up. `py:function:compute_G_bc` is a *tombstone* — it exists only because some bare role couldn't be placed — and an exact hit on it short-circuited before ranking ever ran. It's now held as a fallback and used only when nothing real matches anywhere.

That second layer is the one worth noting: it doesn't show up in unit tests, because reproducing it needs a graph where both the bare tombstone and the dotted definition exist. Replaying the resolver against the live 24,911-node ORPHEUS graph is what caught it — 3/6 targets still resolved to placeholders after the first fix, 9/9 after the second.

## Validation — real ORPHEUS rebuild

Serial `-E` rebuild at `52650a86`, exit 0:

| | before | after |
|---|---|---|
| dead references | 14 | **7** |
| new findings | — | **0** |

All six peierls ghosts resolved. The seventh disappearance (`tests.derivations.test_peierls_moments`) came from the consumer-side `scratch/*` exclusion landing in the same rebuild.

## What this does NOT fix

The 7 remaining findings on ORPHEUS are still all false, from two causes outside this PR's scope:

- **6 of 7** — attributes bound after the class body (`BC.vacuum = BC("vacuum")`) are never indexed. Filed as #40.
- **1 of 7** — a bare `:mod:`derivations`` in a *docstring*. It should have been rescued here and wasn't, because `ast_analyzer.py` has its own resolution logic and never calls `resolve_target_id`. Two independent resolvers; this PR improved one. Unifying them is the prerequisite for #37, since that issue's measured win (+2,965 decidable references) is mostly docstring-side.

## Tests

6 new tests pinning ranking, insertion-order independence, placeholder fallback, tie-breaking, and the exact-match fast path. 636 pass, pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
