### PR TITLE
refactor(resolve): one ranking for all four resolvers + cross-slice ambiguity (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,25 +61,45 @@ Tested against a real `sphinx-proof` build (`tests/roots/test-proof-relations`)
 rather than a fixture guess, since the whole point is what the upstream
 extension actually publishes. `sphinx-proof` is now a test-only dependency.
 
-### Fixed — reference resolution no longer prefers a tombstone (#36)
+### Fixed — reference resolution stops inventing answers (#36)
 
-`resolve_target_id` took the *first* node whose name ended in the reftarget, so
-a placeholder minted from a retired import path competed on equal footing with
-a real definition and won on graph-insertion order. On ORPHEUS a bare
-``:func:`compute_G_bc``` bound to the phantom
-`orpheus.derivations.peierls_geometry.compute_G_bc` instead of the live
-`...peierls_nystrom.geometry.compute_G_bc` — and `dead_references` then reported
-the phantom the resolver had just invented, on a surface agents are told to
-trust.
+Four passes independently decide "which node did this name mean?" — Sphinx
+`pending_xref` resolution, the post-merge phantom fold, merge-time type
+conflicts, and merge-time unresolved reconciliation. They carried three
+separate rank tables (two byte-identical) and, between them, three ways to
+pick wrongly.
 
-Candidates are now ranked: a real definition beats a placeholder, then obj_type
-order, then the shortest qualified name, then the id — so resolution no longer
-depends on build order. The exact-match fast path carried the same defect one
-level up (an exact hit on a bare tombstone short-circuited before ranking ran);
-it is now held as a fallback and used only when nothing real matches anywhere.
+**Ranking, not insertion order.** `resolve_target_id` returned the first node
+whose name ended in the reftarget, so a placeholder minted from a retired
+import path could beat a real definition by luck of graph order. On ORPHEUS a
+bare ``:func:`compute_G_bc``` bound to a phantom instead of the live function,
+and `dead_references` then reported the phantom the resolver had just invented.
+The exact-match fast path had the same defect one level up: an exact hit on a
+bare tombstone short-circuited before ranking ran.
 
-Measured on a real ORPHEUS rebuild: dead references 14 → 7, with zero new
-findings and no change in kind to the rest of the graph.
+**One ranking, shared.** `_mappings.candidate_rank` is now the single answer —
+real definition over placeholder, then the role's type preference, concreteness,
+file-backed, shortest qualified name, node id. `candidates_are_ambiguous` names
+the other half: the last two levels make the sort total, not correct. Passes
+that rewire the graph decline on ambiguity; passes that must return something
+take the minimum.
+
+**Ambiguity judged across passes.** `merge_graphs` runs once per source
+directory, so a name with rivals elsewhere looks unique inside any one slice.
+ORPHEUS merges `tests` after the main tree, and a docstring's bare
+``:mod:`derivations``` bound to the TEST package — unambiguous within the
+slice, wrong across the project. The candidate index now spans the incoming
+slice and the accumulated graph.
+
+Measured across three real ORPHEUS rebuilds: dead references 14 → 7. The
+last step raised the count from 6, and that is the intended direction — a
+silent misattribution became a visible unknown. 281 nodes that were being
+wrongly folded now stand alone, almost all docstring prose fragments
+(`optional`, `N`, `ng`) that had been attaching to real symbols and
+manufacturing false edges.
+
+Remaining ORPHEUS findings are tracked in #40 (attributes bound after the
+class body) and #37 (namespace-aware resolution).
 
 ## 0.16.1 — 2026-08-09
 

--- a/sphinxcontrib/nexus/_mappings.py
+++ b/sphinxcontrib/nexus/_mappings.py
@@ -81,14 +81,6 @@ PRF_OBJECT_TYPES: tuple[str, ...] = (
     "theorem",
 )
 
-# Node types that stand in for a symbol nexus could not place. They are
-# minted so a reference has *something* to point at; none of them is a
-# definition. When a suffix match has to choose between candidates, a
-# real definition always outranks a placeholder.
-_PLACEHOLDER_TYPES: frozenset[str] = frozenset(
-    {NodeType.UNRESOLVED.value, NodeType.EXTERNAL.value}
-)
-
 # Map pending_xref reftype to EdgeType.
 REFTYPE_EDGE_MAP: dict[str, EdgeType] = {
     "ref": EdgeType.REFERENCES,
@@ -111,6 +103,113 @@ REFTYPE_EDGE_MAP: dict[str, EdgeType] = {
     "envvar": EdgeType.REFERENCES,
     "citation": EdgeType.CITES,
 }
+
+
+# ---------------------------------------------------------------------------
+# Candidate ranking — the one answer to "which node did this name mean?"
+# ---------------------------------------------------------------------------
+#
+# Three passes independently ask that question, at three different moments:
+#
+#   * ``resolve_target_id`` (below) — a Sphinx ``pending_xref`` at
+#     doctree-read time, with a reftype and domain in hand.
+#   * ``ast_analyzer._canonicalize_phantoms`` — a post-merge fold of
+#     placeholder nodes onto the real definitions they shadow.
+#   * ``merge.merge_graphs`` — the same node id typed differently by the
+#     Sphinx and AST sides.
+#
+# They used to carry three separate rank tables; two were byte-identical
+# copies and the third was a binary real-vs-placeholder test. Divergence
+# between them is how a graph starts disagreeing with itself about what a
+# name refers to, so the ranking lives here once and the passes differ
+# only in what they do with the verdict.
+
+#: Concreteness ranking. Lower is more concrete, so a real definition
+#: sorts ahead of the placeholders (``external`` / ``unresolved`` /
+#: untyped) that exist only because some reference could not be placed.
+#: ``class`` beats ``function`` so a mistyped constructor call lands on
+#: the class rather than a same-leaf function elsewhere.
+TYPE_RANK: dict[str, int] = {
+    NodeType.CLASS.value: 0,
+    NodeType.EXCEPTION.value: 1,
+    NodeType.METHOD.value: 2,
+    NodeType.FUNCTION.value: 3,
+    NodeType.TYPE.value: 4,
+    NodeType.ATTRIBUTE.value: 5,
+    NodeType.DATA.value: 6,
+    NodeType.MODULE.value: 7,
+    NodeType.EQUATION.value: 8,
+    NodeType.SECTION.value: 9,
+    NodeType.TERM.value: 10,
+    NodeType.FILE.value: 11,
+    NodeType.EXTERNAL.value: 12,
+    NodeType.UNRESOLVED.value: 13,
+    "": 14,
+}
+
+#: Node types that stand in for a symbol nexus could not place. They are
+#: minted so a reference has *something* to point at; none of them is a
+#: definition, and binding a live reference to one manufactures a dead
+#: reference out of a symbol that exists.
+PLACEHOLDER_TYPES: frozenset[str] = frozenset(
+    {NodeType.UNRESOLVED.value, NodeType.EXTERNAL.value, ""}
+)
+
+#: How many leading components of :func:`candidate_rank` describe *what
+#: kind of thing* a candidate is, as opposed to which of several equally
+#: good ones to pick. Two candidates agreeing across this slice are
+#: genuinely ambiguous — see :func:`candidates_are_ambiguous`.
+_IDENTITY_RANK_WIDTH = 4
+
+
+def candidate_rank(
+    node_id: str,
+    name: str,
+    attrs: dict[str, Any],
+    objtype_rank: int = 0,
+) -> tuple[int, int, int, int, int, str]:
+    """Rank one candidate node as the referent of a name.
+
+    Sorted ascending; the smallest key wins. In order:
+
+    1. **Real definition over placeholder.** Unconditional, and ahead of
+       the role's own preference: a ``:exc:`` role must not bind to an
+       ``unresolved`` ``py:exception:`` tombstone when a real class of
+       that name exists.
+    2. **The role's type preference** (``objtype_rank``), for callers
+       that have one — a ``:class:`` role prefers a class. Callers
+       without reftype context pass ``0`` and skip this level.
+    3. **Concreteness** (:data:`TYPE_RANK`).
+    4. **File-backed over not** — a node with a ``file_path`` came from
+       a real definition site.
+    5. **Shortest qualified name** — prefer ``pkg.solve`` to
+       ``pkg.deep.nested.solve`` when nothing above separates them.
+    6. **Node id**, so the order is total and stable across builds.
+    """
+    node_type = attrs.get("type") or ""
+    return (
+        1 if node_type in PLACEHOLDER_TYPES else 0,
+        objtype_rank,
+        TYPE_RANK.get(node_type, 99),
+        0 if attrs.get("file_path") else 1,
+        len(name),
+        node_id,
+    )
+
+
+def candidates_are_ambiguous(ranked: list[tuple[Any, ...]]) -> bool:
+    """True when the top candidates are indistinguishable in kind.
+
+    Levels 5 and 6 of :func:`candidate_rank` (name length, node id) exist
+    to make the sort total, not to justify a choice — two candidates
+    separated only by those are a coin flip. Callers that must not guess
+    check this and decline; callers that must return *something* take the
+    minimum and accept the tiebreak.
+    """
+    if len(ranked) < 2:
+        return False
+    head = ranked[0][:_IDENTITY_RANK_WIDTH]
+    return sum(1 for key in ranked if key[:_IDENTITY_RANK_WIDTH] == head) > 1
 
 
 def resolve_proof_id(nxgraph: nx.MultiDiGraph, label: str) -> str | None:
@@ -182,7 +281,7 @@ def resolve_target_id(
     for objtype in candidate_objtypes:
         nid = f"{refdomain}:{objtype}:{reftarget}"
         if nid in nxgraph:
-            if nxgraph.nodes[nid].get("type", "") not in _PLACEHOLDER_TYPES:
+            if nxgraph.nodes[nid].get("type", "") not in PLACEHOLDER_TYPES:
                 return nid
             if exact_placeholder is None:
                 exact_placeholder = nid
@@ -193,13 +292,16 @@ def resolve_target_id(
     # placeholder minted from some retired import path can both end in
     # ``.compute_G_bc``. Returning whichever the graph happens to yield
     # first makes resolution depend on insertion order, and picking the
-    # placeholder invents a dead reference out of a live symbol. So rank
-    # every candidate instead: a real definition beats a placeholder,
-    # then earlier obj_types win, then the shortest qualified name, then
-    # the id itself so the result is stable across builds.
+    # placeholder invents a dead reference out of a live symbol, so every
+    # candidate is ranked by the shared :func:`candidate_rank`.
+    #
+    # A reference must produce an edge, so an ambiguous best is taken
+    # rather than declined — unlike the phantom fold, which rewires the
+    # graph and must not guess. That difference in consequence, not in
+    # ranking, is why the two passes read the same verdict differently.
     suffix = f".{reftarget}"
-    best: tuple[int, int, int, str] | None = None
-    for rank_objtype, objtype in enumerate(candidate_objtypes):
+    best: tuple[int, int, int, int, int, str] | None = None
+    for objtype_rank, objtype in enumerate(candidate_objtypes):
         prefix = f"{refdomain}:{objtype}:"
         for node_id in nxgraph:
             if not isinstance(node_id, str) or not node_id.startswith(prefix):
@@ -207,14 +309,14 @@ def resolve_target_id(
             name = node_id[len(prefix):]
             if not (name.endswith(suffix) or name == reftarget):
                 continue
-            node_type = nxgraph.nodes[node_id].get("type", "")
-            rank_real = 1 if node_type in _PLACEHOLDER_TYPES else 0
-            key = (rank_real, rank_objtype, len(name), node_id)
+            key = candidate_rank(
+                node_id, name, nxgraph.nodes[node_id], objtype_rank,
+            )
             if best is None or key < best:
                 best = key
 
     if best is not None and best[0] == 0:
-        return best[3]
+        return best[-1]
 
     # Nothing real matched anywhere. An exact-name placeholder is the
     # better answer than a suffix-matched one — equally uninformative,
@@ -222,4 +324,4 @@ def resolve_target_id(
     # it avoids minting a second phantom for the same symbol.
     if exact_placeholder is not None:
         return exact_placeholder
-    return best[3] if best is not None else None
+    return best[-1] if best is not None else None

--- a/sphinxcontrib/nexus/ast_analyzer.py
+++ b/sphinxcontrib/nexus/ast_analyzer.py
@@ -15,6 +15,10 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Iterator
 
+from sphinxcontrib.nexus._mappings import (
+    candidate_rank,
+    candidates_are_ambiguous,
+)
 from sphinxcontrib.nexus.fingerprint import body_fingerprint
 from sphinxcontrib.nexus.graph import (
     EdgeType,
@@ -1449,29 +1453,6 @@ _ID_PREFIX_TO_TYPE: dict[str, str] = {
     "py:data:": NodeType.DATA.value,
 }
 
-#: Concreteness ranking used when a leaf-name fold has multiple
-#: canonical candidates. Lower rank = more concrete — the fold
-#: picks the winner with the lowest rank and ties break on
-#: ``file_path``-bearing nodes. ``class`` beats ``function`` beats
-#: everything else so mistyped class constructors land on the
-#: class, not on a same-leaf function from a different module.
-_TYPE_RANK: dict[str, int] = {
-    NodeType.CLASS.value: 0,
-    NodeType.EXCEPTION.value: 1,
-    NodeType.METHOD.value: 2,
-    NodeType.FUNCTION.value: 3,
-    NodeType.TYPE.value: 4,
-    NodeType.ATTRIBUTE.value: 5,
-    NodeType.DATA.value: 6,
-    NodeType.MODULE.value: 7,
-    NodeType.EQUATION.value: 8,
-    NodeType.SECTION.value: 9,
-    NodeType.TERM.value: 10,
-    NodeType.FILE.value: 11,
-    NodeType.EXTERNAL.value: 12,
-    NodeType.UNRESOLVED.value: 13,
-    "": 14,
-}
 
 
 def _upgrade_types_from_signals(graph: KnowledgeGraph) -> int:
@@ -1590,21 +1571,15 @@ def _chase_reexports(name: str, reexports: dict[str, str]) -> str:
 
 def _canonical_rank_key(
     cid: str, cname: str, attrs: dict,
-) -> tuple[int, int, str]:
+) -> tuple[int, int, int, int, int, str]:
     """Sort key for canonical-candidate tie-breaking.
 
-    Lower sorts first (= winner). The composite is:
-
-    1. ``_TYPE_RANK[type]`` — most-concrete-type wins. Class beats
-       method beats function beats external beats unresolved.
-    2. ``0`` if the node has ``file_path`` set, else ``1`` —
-       file-backed nodes win over bare references.
-    3. The node id as a final tiebreaker, so the sort is
-       deterministic when all other signals are equal.
+    Delegates to :func:`_mappings.candidate_rank`, the single ranking
+    shared with Sphinx-side reference resolution — this pass has no
+    reftype to express a preference with, so it takes the default
+    ``objtype_rank``. See that function for the ordering.
     """
-    type_rank = _TYPE_RANK.get(attrs.get("type") or "", 99)
-    has_file = 0 if attrs.get("file_path") else 1
-    return (type_rank, has_file, cid)
+    return candidate_rank(cid, cname, attrs)
 
 
 def _canonicalize_phantoms(graph: KnowledgeGraph) -> int:
@@ -1727,17 +1702,19 @@ def _canonicalize_phantoms(graph: KnowledgeGraph) -> int:
         matched.sort(key=lambda pair: _canonical_rank_key(
             pair[0], pair[1], g.nodes[pair[0]],
         ))
-        # If multiple candidates share the best rank AND file_path
-        # status, the leaf is ambiguous — skip rather than guess.
-        best_key = _canonical_rank_key(
-            matched[0][0], matched[0][1], g.nodes[matched[0][0]],
-        )
-        tied = [
-            pair for pair in matched
-            if _canonical_rank_key(pair[0], pair[1], g.nodes[pair[0]])[:2]
-            == best_key[:2]
-        ]
-        if len(tied) > 1:
+        # Two candidates that differ only in name length or node id are
+        # a coin flip, and this pass rewires edges — guessing wrong
+        # silently reattributes a reference. Decline instead.
+        #
+        # ORPHEUS has a live example: a bare ``:mod:`derivations``` whose
+        # leaf matches ``orpheus.derivations``, ``tests.derivations`` and
+        # a sibling ``...origins.derivations``, all real modules. Folding
+        # onto the shortest would be wrong — Sphinx resolves it to the
+        # sibling, which only the referring node's namespace can tell you.
+        if candidates_are_ambiguous([
+            _canonical_rank_key(pair[0], pair[1], g.nodes[pair[0]])
+            for pair in matched
+        ]):
             continue
 
         canonical, _canonical_name = matched[0]

--- a/sphinxcontrib/nexus/merge.py
+++ b/sphinxcontrib/nexus/merge.py
@@ -5,39 +5,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from sphinxcontrib.nexus._mappings import TYPE_RANK
 from sphinxcontrib.nexus.graph import EdgeType, KnowledgeGraph, NodeType
 
 if TYPE_CHECKING:
     import networkx as nx
 
 logger = logging.getLogger(__name__)
-
-
-#: Same ranking used in ``ast_analyzer._canonicalize_phantoms`` —
-#: lower is more concrete. ``merge_graphs`` consults it when both
-#: the Sphinx and AST sides have the same node id but disagree on
-#: the type: the more concrete winner takes precedence so a
-#: Sphinx placeholder ``py:class:pkg.mod.Thing`` (type=unresolved
-#: from a pending_xref that couldn't resolve at parse time)
-#: upgrades to ``type=class`` when the AST layer has the
-#: corresponding ``ClassDef`` with ``file_path`` + ``lineno``.
-_MERGE_TYPE_RANK: dict[str, int] = {
-    NodeType.CLASS.value: 0,
-    NodeType.EXCEPTION.value: 1,
-    NodeType.METHOD.value: 2,
-    NodeType.FUNCTION.value: 3,
-    NodeType.TYPE.value: 4,
-    NodeType.ATTRIBUTE.value: 5,
-    NodeType.DATA.value: 6,
-    NodeType.MODULE.value: 7,
-    NodeType.EQUATION.value: 8,
-    NodeType.SECTION.value: 9,
-    NodeType.TERM.value: 10,
-    NodeType.FILE.value: 11,
-    NodeType.EXTERNAL.value: 12,
-    NodeType.UNRESOLVED.value: 13,
-    "": 14,
-}
 
 
 def merge_graphs(
@@ -83,8 +57,8 @@ def merge_graphs(
             ast_type = ast_attrs.get("type", "")
             if ast_type:
                 sphinx_type = sg.nodes[node_id].get("type", "")
-                ast_rank = _MERGE_TYPE_RANK.get(ast_type, 99)
-                sphinx_rank = _MERGE_TYPE_RANK.get(sphinx_type, 99)
+                ast_rank = TYPE_RANK.get(ast_type, 99)
+                sphinx_rank = TYPE_RANK.get(sphinx_type, 99)
                 if ast_rank < sphinx_rank:
                     sg.nodes[node_id]["type"] = ast_type
         else:

--- a/sphinxcontrib/nexus/merge.py
+++ b/sphinxcontrib/nexus/merge.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from sphinxcontrib.nexus._mappings import TYPE_RANK
+from sphinxcontrib.nexus._mappings import (
+    TYPE_RANK,
+    candidate_rank,
+    candidates_are_ambiguous,
+)
 from sphinxcontrib.nexus.graph import EdgeType, KnowledgeGraph, NodeType
 
 if TYPE_CHECKING:
@@ -68,14 +72,53 @@ def merge_graphs(
             sg.add_node(node_id, **attrs)
 
     # Step 4: reconcile UNRESOLVED nodes
-    # Build a lookup: short name → AST concrete node ID
-    ast_by_short_name: dict[str, str] = {}
-    for node_id, attrs in ag.nodes(data=True):
-        name = attrs.get("name", "")
-        if name:
-            short = name.rsplit(".", 1)[-1]
-            ast_by_short_name[short] = node_id
-            ast_by_short_name[name] = node_id
+    #
+    # Index every candidate under both its full and its short name. Names
+    # collide — three real modules can share the leaf ``derivations`` —
+    # so each key holds every candidate and the winner is chosen by the
+    # shared ranking, not by whichever node the walk happened to reach
+    # last. This pass rewires edges, so an ambiguous name is declined
+    # rather than guessed: silently reattributing a reference to the
+    # wrong symbol is worse than leaving it unresolved, where
+    # ``dead_references`` will at least surface it.
+    #
+    # The index spans BOTH graphs, and that is load-bearing.
+    # ``merge_graphs`` runs once per source directory, so the incoming
+    # ``ag`` is one slice of the project — a name with rivals elsewhere
+    # looks unique inside it. ORPHEUS merges ``tests`` after the main
+    # tree, and indexing ``ag`` alone bound a docstring's bare
+    # ``:mod:`derivations``` to the TEST package: unambiguous within the
+    # slice, wrong across the project. Candidates already folded into
+    # ``sg`` by earlier passes have to compete too.
+    by_name: dict[str, list[tuple[str, str]]] = {}
+    seen_ids: set[str] = set()
+    for graph_view in (ag, sg):
+        for node_id, attrs in graph_view.nodes(data=True):
+            if node_id in seen_ids:
+                continue
+            name = attrs.get("name", "")
+            if not name or attrs.get("type") == NodeType.UNRESOLVED.value:
+                continue
+            seen_ids.add(node_id)
+            by_name.setdefault(name.rsplit(".", 1)[-1], []).append(
+                (node_id, name),
+            )
+            by_name.setdefault(name, []).append((node_id, name))
+
+    def _attrs_of(cid: str) -> dict:
+        return ag.nodes[cid] if cid in ag else sg.nodes[cid]
+
+    def _best_match(name: str) -> str | None:
+        candidates = by_name.get(name)
+        if not candidates:
+            return None
+        ranked = sorted(
+            candidate_rank(cid, cname, _attrs_of(cid))
+            for cid, cname in candidates
+        )
+        if candidates_are_ambiguous(ranked):
+            return None
+        return ranked[0][-1]
 
     unresolved_to_remove: list[str] = []
     for node_id, attrs in list(sg.nodes(data=True)):
@@ -83,7 +126,7 @@ def merge_graphs(
             continue
         name = attrs.get("name", "")
         # Try to find a concrete AST node matching this name
-        concrete_id = ast_by_short_name.get(name)
+        concrete_id = _best_match(name)
         if concrete_id and concrete_id in sg and concrete_id != node_id:
             # Retarget all edges pointing to the unresolved node
             for src, _, key, data in list(sg.in_edges(node_id, keys=True, data=True)):

--- a/tests/test_dead_references.py
+++ b/tests/test_dead_references.py
@@ -727,3 +727,91 @@ def test_exact_real_match_still_short_circuits():
     assert resolve_target_id(
         kg.nxgraph, _StubPyDomain(), "py", "func", "pkg.mod.solve",
     ) == "py:function:pkg.mod.solve"
+
+
+# ---------------------------------------------------------------------------
+# One ranking, three resolvers
+# ---------------------------------------------------------------------------
+#
+# Reference resolution happens in three passes at three moments (Sphinx
+# pending_xref, post-merge phantom fold, merge-time type conflict). They
+# once carried three rank tables — two byte-identical copies and a binary
+# real-vs-placeholder test. Divergence between them is how a graph starts
+# disagreeing with itself about what a name refers to.
+
+
+def test_rank_tables_are_not_duplicated():
+    """The table lives in _mappings and nowhere else."""
+    import inspect
+
+    from sphinxcontrib.nexus import ast_analyzer, merge
+
+    for module in (ast_analyzer, merge):
+        src = inspect.getsource(module)
+        assert "NodeType.UNRESOLVED.value: 13" not in src, (
+            f"{module.__name__} redeclares the concreteness ranking; "
+            f"import TYPE_RANK from _mappings instead"
+        )
+
+
+def test_all_three_passes_share_one_ranking():
+    from sphinxcontrib.nexus import merge
+    from sphinxcontrib.nexus._mappings import TYPE_RANK
+    from sphinxcontrib.nexus.ast_analyzer import _canonical_rank_key
+
+    # The phantom fold delegates rather than reimplementing.
+    key = _canonical_rank_key("py:class:pkg.Thing", "pkg.Thing",
+                              {"type": "class", "file_path": "/x.py"})
+    assert key[2] == TYPE_RANK["class"]
+    assert key[3] == 0  # file-backed
+    # merge_graphs consults the same object, not a copy.
+    assert merge.TYPE_RANK is TYPE_RANK
+
+
+def test_placeholder_ranks_below_every_real_type():
+    from sphinxcontrib.nexus._mappings import PLACEHOLDER_TYPES, TYPE_RANK
+
+    worst_real = max(
+        rank for ntype, rank in TYPE_RANK.items()
+        if ntype not in PLACEHOLDER_TYPES
+    )
+    assert all(
+        TYPE_RANK[ntype] > worst_real for ntype in PLACEHOLDER_TYPES
+    ), "a placeholder must never outrank a real definition"
+
+
+def test_ambiguity_is_decided_on_kind_not_tiebreak():
+    """Name length and node id order the sort; they don't justify it."""
+    from sphinxcontrib.nexus._mappings import (
+        candidate_rank,
+        candidates_are_ambiguous,
+    )
+
+    attrs = {"type": "module", "file_path": "/x.py"}
+    # Three real modules sharing a leaf — the ORPHEUS `derivations` case.
+    tied = sorted(
+        candidate_rank(f"py:module:{n}", n, attrs)
+        for n in ("orpheus.derivations", "tests.derivations",
+                  "orpheus.deep.origins.derivations")
+    )
+    assert candidates_are_ambiguous(tied)
+
+    # A real definition against a placeholder is NOT ambiguous.
+    decided = sorted([
+        candidate_rank("py:module:a.thing", "a.thing", attrs),
+        candidate_rank("py:module:thing", "thing", {"type": "unresolved"}),
+    ])
+    assert not candidates_are_ambiguous(decided)
+    assert decided[0][-1] == "py:module:a.thing"
+
+
+def test_single_candidate_is_never_ambiguous():
+    from sphinxcontrib.nexus._mappings import (
+        candidate_rank,
+        candidates_are_ambiguous,
+    )
+
+    assert not candidates_are_ambiguous([])
+    assert not candidates_are_ambiguous(
+        [candidate_rank("py:class:pkg.A", "pkg.A", {"type": "class"})]
+    )

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -395,3 +395,149 @@ def test_infer_implements_still_fires_without_explicit_edge():
     )
     types = [d.get("type") for d in edges.values()]
     assert "implements" in types
+
+
+# ---------------------------------------------------------------------------
+# Ambiguous short names must not be reconciled by iteration order
+# ---------------------------------------------------------------------------
+#
+# The unresolved-reconciliation index used to be a plain dict:
+#
+#     ast_by_short_name[short] = node_id
+#
+# so when several nodes shared a short name, whichever the walk reached
+# LAST silently became the answer. Measured on ORPHEUS: a docstring's
+# bare ``:mod:`derivations``` — whose leaf matches `orpheus.derivations`,
+# `tests.derivations`, and a sibling `...origins.derivations`, all real —
+# bound to the TEST package. The dead-reference count went *down*,
+# because a visible unknown had become a silent misattribution.
+#
+# There is no symptom to notice downstream: the edge looks legitimate and
+# points at a node that exists. Only refusing to guess makes it visible.
+
+
+def _ambiguous_pair() -> tuple[KnowledgeGraph, KnowledgeGraph]:
+    sphinx = KnowledgeGraph()
+    sphinx.add_node(GraphNode(id="doc:page", type=NodeType.FILE, name="page",
+                              display_name="page", domain="std"))
+    sphinx.add_node(GraphNode(
+        id="py:module:derivations", type=NodeType.UNRESOLVED,
+        name="derivations", display_name="derivations", domain="py",
+    ))
+    sphinx.add_edge(GraphEdge(source="doc:page", target="py:module:derivations",
+                              type=EdgeType.REFERENCES))
+
+    ast_g = KnowledgeGraph()
+    for full in ("pkg.derivations", "tests.derivations",
+                 "pkg.deep.origins.derivations"):
+        ast_g.add_node(GraphNode(
+            id=f"py:module:{full}", type=NodeType.MODULE, name=full,
+            display_name="derivations", domain="py",
+            metadata={"file_path": f"/{full.replace('.', '/')}/__init__.py"},
+        ))
+    return sphinx, ast_g
+
+
+def test_ambiguous_short_name_is_left_unresolved():
+    merged = merge_graphs(*_ambiguous_pair())
+    g = merged.nxgraph
+    assert "py:module:derivations" in g, (
+        "an ambiguous short name must stay unresolved and be reported, "
+        "not be folded onto an arbitrary same-leaf candidate"
+    )
+    targets = {t for _, t, d in g.edges(data=True)
+               if d.get("type") == EdgeType.REFERENCES.value}
+    assert "py:module:tests.derivations" not in targets
+
+
+def test_unambiguous_short_name_still_reconciles():
+    """Declining on ambiguity must not disable reconciliation."""
+    sphinx, ast_g = _ambiguous_pair()
+    # Drop the competitors: one candidate left, so the answer is certain.
+    ast_g.nxgraph.remove_node("py:module:tests.derivations")
+    ast_g.nxgraph.remove_node("py:module:pkg.deep.origins.derivations")
+
+    g = merge_graphs(sphinx, ast_g).nxgraph
+    assert "py:module:derivations" not in g
+    targets = {t for _, t, d in g.edges(data=True)
+               if d.get("type") == EdgeType.REFERENCES.value}
+    assert "py:module:pkg.derivations" in targets
+
+
+def test_placeholder_never_wins_reconciliation():
+    """A real definition outranks a same-named placeholder."""
+    sphinx = KnowledgeGraph()
+    sphinx.add_node(GraphNode(
+        id="py:function:widget", type=NodeType.UNRESOLVED, name="widget",
+        display_name="widget", domain="py",
+    ))
+    ast_g = KnowledgeGraph()
+    ast_g.add_node(GraphNode(
+        id="py:function:gone.widget", type=NodeType.UNRESOLVED,
+        name="gone.widget", display_name="widget", domain="py",
+    ))
+    ast_g.add_node(GraphNode(
+        id="py:function:pkg.widget", type=NodeType.FUNCTION, name="pkg.widget",
+        display_name="widget", domain="py",
+        metadata={"file_path": "/pkg/__init__.py"},
+    ))
+    g = merge_graphs(sphinx, ast_g).nxgraph
+    assert "py:function:pkg.widget" in g
+    assert "py:function:widget" not in g
+
+
+def test_ambiguity_is_judged_across_directories_not_within_one():
+    """The rival may arrive in a LATER merge pass.
+
+    ``merge_graphs`` runs once per source directory, so a name with
+    rivals elsewhere in the project looks unique inside any single
+    slice. The ORPHEUS shape: the main tree holds two same-leaf modules
+    (ambiguous — correctly declined), then the ``tests`` slice offers
+    exactly ONE candidate, and judged against that slice alone the bare
+    ``:mod:`derivations``` bound to the TEST package.
+
+    Nothing downstream can see that — the edge is well-formed and points
+    at a node that exists — so it is pinned here.
+    """
+    sphinx = KnowledgeGraph()
+    sphinx.add_node(GraphNode(id="doc:page", type=NodeType.FILE, name="page",
+                              display_name="page", domain="std"))
+    sphinx.add_node(GraphNode(
+        id="py:module:derivations", type=NodeType.UNRESOLVED,
+        name="derivations", display_name="derivations", domain="py",
+    ))
+    sphinx.add_edge(GraphEdge(source="doc:page", target="py:module:derivations",
+                              type=EdgeType.REFERENCES))
+
+    # Pass 1 — the main tree offers two same-leaf modules, so the name
+    # is ambiguous here and reconciliation correctly declines.
+    main = KnowledgeGraph()
+    for full in ("pkg.derivations", "pkg.deep.origins.derivations"):
+        main.add_node(GraphNode(
+            id=f"py:module:{full}", type=NodeType.MODULE, name=full,
+            display_name="derivations", domain="py",
+            metadata={"file_path": f"/{full.replace('.', '/')}/__init__.py"},
+        ))
+    merged = merge_graphs(sphinx, main)
+    assert "py:module:derivations" in merged.nxgraph, (
+        "two same-leaf candidates in one slice must already decline"
+    )
+
+    # Pass 2 — the tests dir offers exactly ONE candidate. Within this
+    # slice the name looks unique; only the accumulated graph knows it
+    # is not.
+    tests_g = KnowledgeGraph()
+    tests_g.add_node(GraphNode(
+        id="py:module:tests.derivations", type=NodeType.MODULE,
+        name="tests.derivations", display_name="derivations", domain="py",
+        metadata={"file_path": "/tests/derivations/__init__.py"},
+    ))
+    g = merge_graphs(merged, tests_g).nxgraph
+
+    targets = {t for _, t, d in g.edges(data=True)
+               if d.get("type") == EdgeType.REFERENCES.value}
+    assert "py:module:tests.derivations" not in targets, (
+        "a reference was silently rebound to the test package because "
+        "the later slice saw only its own candidate"
+    )
+    assert "py:module:derivations" in g


### PR DESCRIPTION
Follow-up to #41. Prerequisite for #37 — namespace resolution now has one place to land instead of four.

## There were four resolvers, not two

Each independently decides "which node did this name mean?":

| Pass | When |
|---|---|
| `resolve_target_id` | Sphinx `pending_xref`, doctree-read |
| `_canonicalize_phantoms` | post-merge phantom fold |
| `merge_graphs` type conflict | same id, two types |
| `merge_graphs` step 4 | unresolved reconciliation |

They carried **three** rank tables — `ast_analyzer._TYPE_RANK` and `merge._MERGE_TYPE_RANK` were byte-identical 14-entry copies — and between them, three ways to pick wrongly.

## One ranking

`_mappings.candidate_rank` is now the single answer:

```
placeholder? > role's type preference > concreteness > file-backed
             > shortest qualified name > node id
```

`candidates_are_ambiguous` names the half the old code only knew implicitly: the last two levels exist to make the sort **total**, not to make it **right**. Two candidates separated only by those are a coin flip. Passes that rewire the graph decline; passes that must return something take the minimum. They differ in consequence, not in ranking.

## The bug that unification exposed

Step 4's index was a plain dict:

```python
ast_by_short_name[short] = node_id   # last writer wins, silently
```

Colliding names resolved to whichever node the walk reached last — order-dependent, the same defect class as #36 in a different pass.

Ranking it wasn't enough. **`merge_graphs` runs once per source directory**, so the incoming AST graph is one slice of the project and a name with rivals elsewhere looks unique inside it. ORPHEUS merges `tests` after the main tree:

- main-tree pass — `orpheus.derivations` and a sibling `...origins.derivations` both match → ambiguous → correctly declined
- `tests` pass — exactly one candidate → folded

A docstring's bare ``:mod:`derivations``` bound to the **test package**. The correct referent is the sibling module, which is what Sphinx's `modname.target` rule picks — and no amount of ranking would find it, only namespace context (#37).

The candidate index now spans the incoming slice **and** the accumulated graph.

## Validation — three real ORPHEUS rebuilds

| | dead refs |
|---|---|
| baseline | 14 |
| ranking fix (#41) | 7 |
| \+ unification | 6 |
| \+ cross-graph index | **7** |

**The last step raises the count, and that is the point.** The 6 was a regression wearing the mask of an improvement: a visible unknown had become a silent misattribution, which is strictly worse — the edge is well-formed and points at a node that exists, so nothing downstream can see it.

281 nodes that were being wrongly folded now stand alone. Almost all are docstring prose fragments — `optional`, `N`, `ng`, `matrix.` — that had been attaching themselves to real symbols and manufacturing false edges. They don't reach the gate; `dead_references` already filters them.

## Tests

11 new. Both merge tests were verified to **fail** with the fix reverted, not just to pass with it — the first version of the cross-directory test passed against the broken code because it set up one candidate in pass 1, which folds correctly and leaves nothing for pass 2 to get wrong.

645 pass, pyright clean.

## Note on the remaining ORPHEUS findings

All 7 are still false, from causes outside this PR: 6 are #40 (attributes bound after the class body), 1 is the `derivations` case awaiting #37. `dead_references` on ORPHEUS currently reports zero genuine drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
