### PR TITLE
feat(resolve): resolve relative py references against the referrer's namespace (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,38 @@ Tested against a real `sphinx-proof` build (`tests/roots/test-proof-relations`)
 rather than a fixture guess, since the whole point is what the upstream
 extension actually publishes. `sphinx-proof` is now a test-only dependency.
 
+### Added — relative references resolve against their namespace (#37)
+
+Half of a real project's Python references are relative —
+``:meth:`Quadrature.product```, ``:class:`SNMesh```, ``:meth:`apply``` — and
+Sphinx resolves those against the current module and class. The graph already
+knew each reference's source node, so the context was present and simply never
+consulted.
+
+`_resolve_relative_references` reproduces `PythonDomain.find_obj` with
+`searchmode=0`: `modname.classname.target`, then `modname.target`, then
+`target` **as a fully qualified key**. That last step is the counterintuitive
+one and is now encoded — the registry is keyed by full dotted names, so a bare
+``:func:`solve``` does not resolve merely because its module was
+`automodule`-d, which is why adding autodoc coverage cannot fix relative
+references from the consumer side.
+
+**It retargets the edge, not the node.** A phantom is shared by every referrer
+that spelled the same name: on ORPHEUS, 532 bare phantoms have more than one
+distinct source and ``:meth:`apply``` alone is referenced from 132 docstrings.
+Folding the node would force one answer on all of them; only the edge carries
+the namespace that decides. Each operator class's ``:meth:`apply``` now binds
+to its own method.
+
+Runs before `_canonicalize_phantoms` — namespace context is an answer,
+leaf-matching is a guess, and an answer must not lose to a guess that sorts
+first.
+
+Measured on ORPHEUS: **89.6%** of Python-to-Python references land on a real
+definition (10215/11407). The remainder is the honest bucket — builtins,
+third-party (`numpy.linalg.eig`, `mpmath.quad`), and relative names whose own
+namespace genuinely lacks them, none of which Sphinx would link either.
+
 ### Fixed — reference resolution stops inventing answers (#36)
 
 Four passes independently decide "which node did this name mean?" — Sphinx

--- a/sphinxcontrib/nexus/__init__.py
+++ b/sphinxcontrib/nexus/__init__.py
@@ -198,7 +198,10 @@ def _run_ast_analysis(app: Sphinx, graph: Any) -> None:
     # then apply any non-LLM verification registries. Both paths run
     # BEFORE ``_infer_implements`` so the token-intersection heuristic
     # honors every explicit edge as "already-known".
-    from sphinxcontrib.nexus.ast_analyzer import _canonicalize_phantoms
+    from sphinxcontrib.nexus.ast_analyzer import (
+        _canonicalize_phantoms,
+        _resolve_relative_references,
+    )
     from sphinxcontrib.nexus.directives import apply_pending_edges
     from sphinxcontrib.nexus.merge import (
         _infer_implements,
@@ -214,6 +217,12 @@ def _run_ast_analysis(app: Sphinx, graph: Any) -> None:
     # couldn't see get collapsed into their AST-derived canonicals.
     # This is the "post-merge" pass that catches the ORPHEUS
     # re-export shape where both sides contribute half of the bug.
+    #
+    # Relative references resolve FIRST. Namespace context is an answer
+    # — it reproduces what Sphinx itself would link — while leaf-matching
+    # is a guess among same-named candidates. An answer must not lose to
+    # a guess that happens to sort first.
+    _resolve_relative_references(graph)
     _canonicalize_phantoms(graph)
 
     write_verifies_edges(graph.nxgraph)

--- a/sphinxcontrib/nexus/ast_analyzer.py
+++ b/sphinxcontrib/nexus/ast_analyzer.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from sphinxcontrib.nexus._mappings import (
+    PLACEHOLDER_TYPES,
     candidate_rank,
     candidates_are_ambiguous,
 )
@@ -1580,6 +1581,166 @@ def _canonical_rank_key(
     ``objtype_rank``. See that function for the ordering.
     """
     return candidate_rank(cid, cname, attrs)
+
+
+#: Python-domain node id prefixes, in the order a lookup should prefer
+#: them when the role itself does not say. ``py:obj:``-style roles and
+#: docstring prose rarely name the objtype correctly, so a candidate is
+#: accepted from any of these.
+_PY_LOOKUP_PREFIXES: tuple[str, ...] = (
+    "py:class:", "py:exception:", "py:method:", "py:function:",
+    "py:attribute:", "py:data:", "py:type:", "py:module:",
+)
+
+
+def _namespace_of(g: "Any", node_id: str) -> tuple[str, str]:
+    """The ``(modname, classname)`` a reference in this node resolves against.
+
+    Sphinx resolves a relative Python reference against the *current*
+    module and class. For a docstring that context is the namespace of
+    the node the docstring belongs to, which the graph already records
+    as ``contains`` edges — walk them up rather than re-deriving it from
+    the file path.
+
+    Returns empty strings for either component that does not apply (a
+    module-level function has no class; a module is its own modname).
+    """
+    modname = classname = ""
+    current = node_id
+    for _ in range(4):  # module > class > method is the deepest real chain
+        attrs = g.nodes.get(current) or {}
+        ntype = attrs.get("type", "")
+        name = attrs.get("name", "") or ""
+        if ntype == NodeType.MODULE.value:
+            modname = name
+            break
+        if ntype in (NodeType.CLASS.value, NodeType.EXCEPTION.value):
+            classname = name.rsplit(".", 1)[-1]
+        # A symbol has more than one ``contains`` parent: its lexical
+        # owner (module/class) AND every doc page that documents it.
+        # Only the Python chain carries a namespace — following a
+        # ``doc:`` parent dead-ends on a node with no module, which
+        # reads as "no context" and silently declines the reference.
+        parents = [
+            src for src, _, data in g.in_edges(current, data=True)
+            if data.get("type") == EdgeType.CONTAINS.value
+            and isinstance(src, str) and src.startswith("py:")
+        ]
+        if not parents:
+            break
+        current = parents[0]
+    return modname, classname
+
+
+def _find_in_namespace(
+    g: "Any",
+    target: str,
+    modname: str,
+    classname: str,
+    preferred_prefix: str,
+) -> str | None:
+    """Resolve ``target`` the way ``PythonDomain.find_obj`` would.
+
+    Search order with ``searchmode=0`` (the default — ``refspecific`` is
+    set only by a leading dot):
+
+    1. ``modname.classname.target``
+    2. ``modname.target``
+    3. ``target`` — **as a fully qualified key**, not as a bare name
+
+    Step 3 is the counterintuitive one and it is load-bearing: the domain
+    registry is keyed by full dotted names, so a bare ``:func:`solve```
+    does NOT resolve merely because its module was ``automodule``-d. That
+    is why "just add autodoc coverage" cannot fix relative references,
+    and why this pass has to exist.
+    """
+    candidates = []
+    if modname and classname:
+        candidates.append(f"{modname}.{classname}.{target}")
+    if modname:
+        candidates.append(f"{modname}.{target}")
+    candidates.append(target)
+
+    prefixes = (
+        (preferred_prefix, *(p for p in _PY_LOOKUP_PREFIXES if p != preferred_prefix))
+        if preferred_prefix in _PY_LOOKUP_PREFIXES
+        else _PY_LOOKUP_PREFIXES
+    )
+    for qualname in candidates:
+        for prefix in prefixes:
+            nid = f"{prefix}{qualname}"
+            node = g.nodes.get(nid)
+            if node is not None and node.get("type") not in PLACEHOLDER_TYPES:
+                return nid
+    return None
+
+
+def _resolve_relative_references(graph: KnowledgeGraph) -> int:
+    """Bind relative Python references using the referrer's namespace.
+
+    Half of a real project's py-domain references are relative
+    (``:meth:`Quadrature.product```, ``:class:`SNMesh```, ``:meth:`apply```)
+    and mean different things in different modules. The graph already
+    knows each reference's source node, so the context Sphinx would use
+    is already present — it just was not consulted.
+
+    **Retargets the edge, not the node.** A phantom is shared by every
+    referrer that spelled the same name: measured on ORPHEUS, 532 bare
+    phantoms have more than one distinct source and ``:meth:`apply```
+    alone is referenced from 132. Folding the node would force one
+    answer on all of them; only the edge carries the namespace that
+    decides. Phantoms left with no remaining references are dropped.
+
+    Runs BEFORE ``_canonicalize_phantoms``: namespace context is an
+    answer, leaf-matching is a guess, and an answer must not lose to a
+    guess that happens to sort first.
+    """
+    g = graph.nxgraph
+    resolved = 0
+    namespaces: dict[str, tuple[str, str]] = {}
+    touched: set[str] = set()
+
+    for src, tgt, key, data in list(g.edges(keys=True, data=True)):
+        tgt_attrs = g.nodes.get(tgt) or {}
+        if tgt_attrs.get("type") not in PLACEHOLDER_TYPES:
+            continue
+        if not isinstance(tgt, str) or not tgt.startswith("py:"):
+            continue
+        target_name = tgt_attrs.get("name", "") or ""
+        if not target_name:
+            continue
+
+        if src not in namespaces:
+            namespaces[src] = _namespace_of(g, src)
+        modname, classname = namespaces[src]
+        if not modname:
+            # No namespace to resolve against — an .rst page with no
+            # ``currentmodule``, or a node the contains chain never
+            # reached a module from. Report it as-is rather than guess.
+            continue
+
+        prefix = tgt[:tgt.index(":", 3) + 1] if tgt.count(":") >= 2 else ""
+        found = _find_in_namespace(g, target_name, modname, classname, prefix)
+        if found is None or found == tgt:
+            continue
+
+        g.remove_edge(src, tgt, key=key)
+        g.add_edge(src, found, **data)
+        touched.add(tgt)
+        resolved += 1
+
+    # Drop phantoms nothing points at any more. A phantom with surviving
+    # references is still the honest answer for those referrers.
+    for nid in touched:
+        if nid in g and g.in_degree(nid) == 0 and g.out_degree(nid) == 0:
+            g.remove_node(nid)
+
+    if resolved:
+        logger.info(
+            "Resolved %d relative references against their namespace",
+            resolved,
+        )
+    return resolved
 
 
 def _canonicalize_phantoms(graph: KnowledgeGraph) -> int:

--- a/tests/test_dead_references.py
+++ b/tests/test_dead_references.py
@@ -815,3 +815,223 @@ def test_single_candidate_is_never_ambiguous():
     assert not candidates_are_ambiguous(
         [candidate_rank("py:class:pkg.A", "pkg.A", {"type": "class"})]
     )
+
+
+# ---------------------------------------------------------------------------
+# Relative reference resolution (issue #37)
+# ---------------------------------------------------------------------------
+#
+# Half of a real project's py-domain references are relative
+# (:meth:`Quadrature.product`, :class:`SNMesh`, :meth:`apply`) and Sphinx
+# resolves them against the current module and class. The graph already
+# knows each reference's source node, so that context is present — it
+# just was not consulted.
+
+
+def _ns_graph() -> KnowledgeGraph:
+    """A module with a class, both defining an `apply`."""
+    kg = KnowledgeGraph()
+
+    def mod(name):
+        kg.add_node(GraphNode(id=f"py:module:{name}", type=NodeType.MODULE,
+                              name=name, display_name=name.rsplit(".", 1)[-1],
+                              domain="py", metadata={"file_path": f"/{name}.py"}))
+
+    def sym(kind, ntype, name, parent):
+        nid = f"py:{kind}:{name}"
+        kg.add_node(GraphNode(id=nid, type=ntype, name=name,
+                              display_name=name.rsplit(".", 1)[-1], domain="py",
+                              metadata={"file_path": "/x.py"}))
+        kg.add_edge(GraphEdge(source=parent, target=nid, type=EdgeType.CONTAINS))
+        return nid
+
+    mod("pkg.alpha")
+    mod("pkg.beta")
+    sym("class", NodeType.CLASS, "pkg.alpha.Solver", "py:module:pkg.alpha")
+    sym("method", NodeType.METHOD, "pkg.alpha.Solver.apply",
+        "py:class:pkg.alpha.Solver")
+    sym("class", NodeType.CLASS, "pkg.beta.Filter", "py:module:pkg.beta")
+    sym("method", NodeType.METHOD, "pkg.beta.Filter.apply",
+        "py:class:pkg.beta.Filter")
+    return kg
+
+
+def _phantom_ref(kg, source_id, phantom_id, name):
+    if phantom_id not in kg.nxgraph:
+        kg.add_node(GraphNode(id=phantom_id, type=NodeType.UNRESOLVED,
+                              name=name, display_name=name, domain="py"))
+    kg.add_edge(GraphEdge(source=source_id, target=phantom_id,
+                          type=EdgeType.REFERENCES))
+
+
+def test_same_bare_name_resolves_differently_per_namespace():
+    """The load-bearing case: one phantom, two correct answers.
+
+    Measured on ORPHEUS: 532 bare phantoms have more than one distinct
+    referrer, and `:meth:`apply`` alone is referenced from 132. Folding
+    the shared NODE would force one answer on all of them — only the
+    edge carries the namespace that decides.
+    """
+    from sphinxcontrib.nexus.ast_analyzer import _resolve_relative_references
+
+    kg = _ns_graph()
+    _phantom_ref(kg, "py:method:pkg.alpha.Solver.apply", "py:function:apply", "apply")
+    _phantom_ref(kg, "py:method:pkg.beta.Filter.apply", "py:function:apply", "apply")
+
+    assert _resolve_relative_references(kg) == 2
+    g = kg.nxgraph
+    out = lambda s: {t for _, t, d in g.out_edges(s, data=True)
+                     if d.get("type") == EdgeType.REFERENCES.value}
+    assert out("py:method:pkg.alpha.Solver.apply") == {"py:method:pkg.alpha.Solver.apply"}
+    assert out("py:method:pkg.beta.Filter.apply") == {"py:method:pkg.beta.Filter.apply"}
+    # Fully dereferenced, so the phantom is gone.
+    assert "py:function:apply" not in g
+
+
+def test_class_namespace_beats_module_namespace():
+    """find_obj tries modname.classname.target before modname.target."""
+    from sphinxcontrib.nexus.ast_analyzer import _resolve_relative_references
+
+    kg = _ns_graph()
+    # A module-level `apply` competing with the class's.
+    kg.add_node(GraphNode(id="py:function:pkg.alpha.apply", type=NodeType.FUNCTION,
+                          name="pkg.alpha.apply", display_name="apply", domain="py",
+                          metadata={"file_path": "/x.py"}))
+    kg.add_edge(GraphEdge(source="py:module:pkg.alpha",
+                          target="py:function:pkg.alpha.apply",
+                          type=EdgeType.CONTAINS))
+    _phantom_ref(kg, "py:method:pkg.alpha.Solver.apply", "py:function:apply", "apply")
+
+    _resolve_relative_references(kg)
+    targets = {t for _, t, d in kg.nxgraph.out_edges(
+        "py:method:pkg.alpha.Solver.apply", data=True)
+        if d.get("type") == EdgeType.REFERENCES.value}
+    assert targets == {"py:method:pkg.alpha.Solver.apply"}
+
+
+def test_bare_name_is_looked_up_as_a_full_key():
+    """The counterintuitive rule, encoded.
+
+    The domain registry is keyed by full dotted names, so a bare
+    `:func:`helper`` resolves only if a TOP-LEVEL `helper` exists — not
+    merely because its module was automodule'd. This is why "add autodoc
+    coverage" cannot fix relative references.
+    """
+    from sphinxcontrib.nexus.ast_analyzer import _resolve_relative_references
+
+    kg = _ns_graph()
+    # `zzz` exists nowhere in pkg.alpha's namespace and has no top-level
+    # definition — it must stay unresolved.
+    _phantom_ref(kg, "py:module:pkg.alpha", "py:function:zzz", "zzz")
+    assert _resolve_relative_references(kg) == 0
+    assert "py:function:zzz" in kg.nxgraph
+
+    # Now give it a genuine top-level definition: step 3 finds it.
+    kg2 = _ns_graph()
+    kg2.add_node(GraphNode(id="py:function:zzz", type=NodeType.UNRESOLVED,
+                           name="zzz", display_name="zzz", domain="py"))
+    kg2.add_node(GraphNode(id="py:function:toplevel", type=NodeType.FUNCTION,
+                           name="toplevel", display_name="toplevel", domain="py",
+                           metadata={"file_path": "/t.py"}))
+    kg2.add_edge(GraphEdge(source="py:module:pkg.alpha",
+                           target="py:function:toplevel_ref",
+                           type=EdgeType.REFERENCES))
+    kg2.add_node(GraphNode(id="py:function:toplevel_ref", type=NodeType.UNRESOLVED,
+                           name="toplevel", display_name="toplevel", domain="py"))
+    assert _resolve_relative_references(kg2) == 1
+    targets = {t for _, t, d in kg2.nxgraph.out_edges("py:module:pkg.alpha", data=True)
+               if d.get("type") == EdgeType.REFERENCES.value}
+    assert "py:function:toplevel" in targets
+
+
+def test_phantom_survives_while_any_referrer_still_needs_it():
+    """Partial resolution must not delete the node out from under the rest."""
+    from sphinxcontrib.nexus.ast_analyzer import _resolve_relative_references
+
+    kg = _ns_graph()
+    # One referrer can resolve it; one has no namespace at all.
+    kg.add_node(GraphNode(id="doc:page", type=NodeType.FILE, name="page",
+                          display_name="page", domain="std"))
+    _phantom_ref(kg, "py:method:pkg.alpha.Solver.apply", "py:function:apply", "apply")
+    _phantom_ref(kg, "doc:page", "py:function:apply", "apply")
+
+    assert _resolve_relative_references(kg) == 1
+    g = kg.nxgraph
+    assert "py:function:apply" in g, (
+        "an .rst page with no currentmodule has no namespace to resolve "
+        "against; its reference must survive, not vanish"
+    )
+    assert {t for _, t, d in g.out_edges("doc:page", data=True)} == {"py:function:apply"}
+
+
+def test_no_namespace_means_no_guess():
+    """A page with no module context is declined, not guessed."""
+    from sphinxcontrib.nexus.ast_analyzer import _resolve_relative_references
+
+    kg = _ns_graph()
+    kg.add_node(GraphNode(id="doc:page", type=NodeType.FILE, name="page",
+                          display_name="page", domain="std"))
+    _phantom_ref(kg, "doc:page", "py:function:apply", "apply")
+    assert _resolve_relative_references(kg) == 0
+
+
+def test_real_targets_are_never_retargeted():
+    from sphinxcontrib.nexus.ast_analyzer import _resolve_relative_references
+
+    kg = _ns_graph()
+    kg.add_edge(GraphEdge(source="py:module:pkg.beta",
+                          target="py:method:pkg.alpha.Solver.apply",
+                          type=EdgeType.REFERENCES))
+    assert _resolve_relative_references(kg) == 0
+
+
+def test_namespace_walk_ignores_documenting_doc_pages():
+    """A symbol's ``contains`` parents include every doc page that
+    documents it, not just its lexical owner.
+
+    Ordering is what makes this bite: Sphinx extraction runs before AST
+    analysis, so the ``doc:`` parent edge is inserted FIRST and leads
+    ``in_edges``. Measured on ORPHEUS, `CoupledOperator.solve` lists
+    `doc:api/numerics` ahead of `py:class:...CoupledOperator`. Following
+    it dead-ends on a node with no module, which is indistinguishable
+    from "no namespace" — so the reference was declined for the wrong
+    reason and the whole pass looked like a near-no-op.
+    """
+    from sphinxcontrib.nexus.ast_analyzer import (
+        _namespace_of,
+        _resolve_relative_references,
+    )
+
+    kg = KnowledgeGraph()
+    kg.add_node(GraphNode(id="py:module:pkg.alpha", type=NodeType.MODULE,
+                          name="pkg.alpha", display_name="alpha", domain="py",
+                          metadata={"file_path": "/a.py"}))
+    kg.add_node(GraphNode(id="doc:api/alpha", type=NodeType.FILE,
+                          name="api/alpha", display_name="alpha", domain="std"))
+    kg.add_node(GraphNode(id="py:class:pkg.alpha.Solver", type=NodeType.CLASS,
+                          name="pkg.alpha.Solver", display_name="Solver",
+                          domain="py", metadata={"file_path": "/a.py"}))
+    kg.add_node(GraphNode(id="py:method:pkg.alpha.Solver.apply",
+                          type=NodeType.METHOD, name="pkg.alpha.Solver.apply",
+                          display_name="apply", domain="py",
+                          metadata={"file_path": "/a.py"}))
+    # Doc-page parents first — the Sphinx-then-AST insertion order.
+    kg.add_edge(GraphEdge(source="doc:api/alpha",
+                          target="py:class:pkg.alpha.Solver",
+                          type=EdgeType.CONTAINS))
+    kg.add_edge(GraphEdge(source="doc:api/alpha",
+                          target="py:method:pkg.alpha.Solver.apply",
+                          type=EdgeType.CONTAINS))
+    kg.add_edge(GraphEdge(source="py:module:pkg.alpha",
+                          target="py:class:pkg.alpha.Solver",
+                          type=EdgeType.CONTAINS))
+    kg.add_edge(GraphEdge(source="py:class:pkg.alpha.Solver",
+                          target="py:method:pkg.alpha.Solver.apply",
+                          type=EdgeType.CONTAINS))
+
+    assert _namespace_of(kg.nxgraph, "py:method:pkg.alpha.Solver.apply") == (
+        "pkg.alpha", "Solver",
+    )
+    _phantom_ref(kg, "py:method:pkg.alpha.Solver.apply", "py:function:apply",
+                 "apply")
+    assert _resolve_relative_references(kg) == 1


### PR DESCRIPTION
Closes #37. Builds on #42's single resolver.

## What it does

Reproduces `PythonDomain.find_obj` with `searchmode=0`, using the namespace of the node the reference lives in:

```
modname.classname.target
modname.target
target                     # as a FULL key, not a bare name
```

Step 3 is the counterintuitive one the issue asked to encode: the registry is keyed by full dotted names, so a bare ``:func:`solve``` does **not** resolve merely because its module was `automodule`-d. That is why "add autodoc coverage" cannot fix relative references consumer-side.

Namespace comes from walking `contains` edges up from the referrer — no new metadata, and it works for Sphinx-side nodes too.

## The design point the issue didn't state: retarget the edge, not the node

Two measurements taken before writing anything:

| | |
|---|---|
| references to unresolved, from **docstrings** (function+method) | 25,780 |
| references to unresolved, from **doc pages** | 127 |
| bare phantoms with **more than one** distinct referrer | **532** |
| distinct referrers of ``:meth:`apply``` alone | **132** |

132 docstrings saying `apply` mean up to 132 *different* methods, each resolving against its own class. A single shared phantom node cannot represent that — so relative resolution retargets the **edge**. `_canonicalize_phantoms` folds nodes, which is right for absolute dotted paths (they mean the same thing everywhere) and wrong for relative names.

The results show it working:

```
LinearOperator                → LinearOperator.apply
StreamingOperator             → StreamingOperator.apply
RadialCharacteristicOperator  → RadialCharacteristicOperator.apply
```

Ordering: this runs **before** `_canonicalize_phantoms`. Namespace context is an answer; leaf-matching is a guess. An answer must not lose to a guess that sorts first.

## A bug the counts hid

First ORPHEUS run resolved almost nothing — 128 of 132 `apply` referrers still declined. Cause:

```
py:method:...CoupledOperator.solve
   parent: doc:api/numerics            ← leads in_edges
   parent: py:class:...CoupledOperator
```

A symbol's `contains` parents include **every doc page documenting it**, and Sphinx extraction runs before AST analysis, so the `doc:` edge is inserted first. Taking `parents[0]` dead-ended on a `file` node with no module — indistinguishable from "no namespace" — so references were declined for the wrong reason. The walk now follows only the `py:` chain.

## Results — ORPHEUS

**89.6%** of py→py references land on a real definition (10215/11407).

The remaining 1,192 are the honest bucket, and are listed here rather than glossed: builtins (`NotImplementedError`, `ValueError`, `TypeError`), third-party (`numpy.linalg.eig`, `mpmath.quad`, `sympy.simplify`, `pytest.fail`), and protocol-style relative names whose own namespace genuinely lacks them (`apply` ×35, `from_mesh`, `greens_function`). Sphinx does not link any of these either — they render as plain text today.

## Tests

7 new, including the 132-referrer case, class-namespace-beats-module ordering, the full-key rule, partial resolution leaving a phantom alive for referrers that still need it, and the doc-page parent hazard.

The doc-page test was **verified to fail with the fix reverted**. Its first version did not — the fixture happened to insert the `py:` parent first, so `parents[0]` was correct regardless and the test passed against broken code. It now builds parents in the real Sphinx-then-AST order.

652 pass, pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
