### PR TITLE
feat(ast): index post-class-body attributes and `#:` comment prose (#40, #38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,38 @@ Measured on ORPHEUS: **89.6%** of Python-to-Python references land on a real
 definition (10215/11407). The remainder is the honest bucket — builtins,
 third-party (`numpy.linalg.eig`, `mpmath.quad`), and relative names whose own
 namespace genuinely lacks them, none of which Sphinx would link either.
+### Added — attributes bound after the class body, and `#:` comment prose (#40, #38)
+
+Landed together because #38 documents the ordering hazard between them: widening
+the scanned reference surface before the indexer can see an attribute
+manufactures false dead references.
+
+**Post-class-body attributes.** The standard way to build enum-like singletons
+on a non-Enum class was invisible to the indexer::
+
+    @dataclass(frozen=True)
+    class BC:
+        kind: str
+
+    BC.vacuum = BC("vacuum")   # type: ignore[attr-defined]
+
+These are real class attributes at import time — autodoc documents them and
+``:data:`BC.vacuum``` renders as a working link — but the class body holds no
+trace, so every reference was reported dead. Bound only for classes defined in
+the same module: ``os.environ = {}`` is somebody else's namespace.
+
+**`#:` attribute comments.** Sphinx's attribute-comment form carries real
+cross-references (168 py-domain roles on ORPHEUS) and `ast` discards comments
+outright, so the token stream is the only way to read them. Uses `tokenize`
+rather than a line regex, so a ``#:`` inside a string literal is not mistaken
+for one; handles both the leading-block and trailing (``x = 1  #: doc``) forms.
+
+**`:numref:` crosswalk.** ``:numref:`peierls-3d``` on an equation label names the
+same target as ``:eq:``; it was minting a `math:numref:` placeholder beside the
+real equation node, splitting one equation's references across two ids. Guarded
+by an existence check, so a figure reference cannot fabricate an equation.
+`:numref:` to figures and tables remains unresolved — that is the std-label
+namespace and separate work.
 
 ### Fixed — reference resolution stops inventing answers (#36)
 

--- a/sphinxcontrib/nexus/_mappings.py
+++ b/sphinxcontrib/nexus/_mappings.py
@@ -259,6 +259,17 @@ def resolve_target_id(
     if reftype == "eq":
         nid = f"math:equation:{reftarget}"
         return nid if nid in nxgraph else None
+    if reftype == "numref":
+        # ``:numref:`peierls-3d``` on an equation label is a legitimate
+        # and common spelling — it renders the equation NUMBER rather
+        # than the label, but it names the same target. Without this it
+        # minted a ``math:numref:`` placeholder standing beside the real
+        # equation node, splitting one equation's references across two
+        # ids. Falls through to the ordinary std-domain path (figures,
+        # tables, sections) when no such equation exists.
+        nid = f"math:equation:{reftarget}"
+        if nid in nxgraph:
+            return nid
     if refdomain == "prf":
         return resolve_proof_id(nxgraph, reftarget)
 

--- a/sphinxcontrib/nexus/ast_analyzer.py
+++ b/sphinxcontrib/nexus/ast_analyzer.py
@@ -674,6 +674,71 @@ def _discriminated_tags(
 # ---------------------------------------------------------------------------
 
 
+def attribute_comments(source: str) -> dict[int, str]:
+    """Map each ``#:``-documented statement's line to its comment prose.
+
+    Sphinx's attribute-comment form documents the statement below it::
+
+        #: Spatial axis names, positional-by-axis — the crosswalk that
+        #: :class:`FaceLayout` and :attr:`SNMesh.bc` both key on.
+        AXIS_NAMES = ("x", "y", "z")
+
+    That prose carries real cross-references (168 py-domain roles on
+    ORPHEUS) and ``ast`` discards comments outright, so the token stream
+    is the only way to see it. ``tokenize`` rather than a line regex
+    specifically so a ``#:`` inside a string literal is not mistaken for
+    an attribute comment.
+
+    A trailing form (``x = 1  #: doc``) documents the statement it sits
+    on; a leading block documents the next one. Both are returned keyed
+    by the documented statement's line number.
+    """
+    import io
+    import tokenize as _tokenize
+
+    result: dict[int, str] = {}
+    block: list[str] = []
+    block_start_seen = False
+    try:
+        tokens = list(_tokenize.generate_tokens(io.StringIO(source).readline))
+    except (_tokenize.TokenError, IndentationError, SyntaxError):
+        # Malformed source: ast.parse already reports it. Losing the
+        # comments is strictly better than failing the whole analysis.
+        return result
+
+    prev_end_row = 0
+    for tok in tokens:
+        if tok.type == _tokenize.COMMENT:
+            text = tok.string
+            if not text.startswith("#:"):
+                block = []
+                block_start_seen = False
+                continue
+            prose = text[2:].strip()
+            # A comment sharing a line with code is a trailing comment:
+            # it documents THAT line, not the next statement.
+            if tok.start[1] > 0 and tok.line[:tok.start[1]].strip():
+                result[tok.start[0]] = prose
+                block = []
+                block_start_seen = False
+            else:
+                block.append(prose)
+                block_start_seen = True
+        elif tok.type in (_tokenize.NL, _tokenize.COMMENT):
+            continue
+        elif tok.type in (_tokenize.NEWLINE, _tokenize.INDENT,
+                          _tokenize.DEDENT, _tokenize.ENDMARKER):
+            continue
+        elif block_start_seen:
+            # First real token after a ``#:`` block — the statement it
+            # documents.
+            result[tok.start[0]] = " ".join(block)
+            block = []
+            block_start_seen = False
+        prev_end_row = tok.end[0]
+    return result
+
+
 def _iter_name_targets(target: ast.expr) -> Iterator[str]:
     """Yield plain names bound by an assignment target.
 
@@ -715,6 +780,7 @@ class CodeVisitor(ast.NodeVisitor):
         module_name: str,
         file_path: str,
         is_test_file: bool = False,
+        attr_comments: dict[int, str] | None = None,
     ) -> None:
         self._module_name = module_name
         self._file_path = file_path
@@ -744,6 +810,16 @@ class CodeVisitor(ast.NodeVisitor):
         # (only ``ast.walk``-ed for calls), so these visitors cannot
         # fire at function scope.
         self._class_depth = 0
+        # Classes defined in THIS module: local name → qualified name.
+        # Used to bind ``Cls.attr = ...`` statements that appear after
+        # the class body back onto the class they extend. Restricted to
+        # locally-defined classes on purpose — ``mod.CONST = 1`` on an
+        # imported module is somebody else's namespace, not ours.
+        self._classes_defined: dict[str, str] = {}
+        # Line number of a ``#:``-documented statement → its prose.
+        # Comments are gone from the AST, so this is pre-scanned from
+        # the token stream and joined back on by line.
+        self._attr_comments: dict[int, str] = attr_comments or {}
         # Module-scope ``from X import Y`` aliases: public dotted path
         # → defining dotted path. ``analyze_directory`` aggregates
         # these into graph metadata so phantom canonicalization can
@@ -800,17 +876,24 @@ class CodeVisitor(ast.NodeVisitor):
         node: ast.AsyncFunctionDef | ast.FunctionDef | ast.ClassDef | ast.Module,
         source_id: str,
     ) -> None:
-        """Extract Sphinx role references from docstring.
+        """Extract Sphinx role references from a docstring."""
+        docstring = ast.get_docstring(node)
+        if docstring:
+            self._add_text_refs(docstring, source_id)
+
+    def _add_text_refs(self, docstring: str, source_id: str) -> None:
+        """Extract Sphinx role references from documentation prose.
 
         Python-domain roles produce ``py:<objtype>:<name>`` target IDs that
         reconcile against AST-discovered symbols. The math roles ``:math:``
         and ``:eq:`` instead point at Sphinx math equation labels in the
         ``math:equation:<label>`` namespace, which is what Sphinx's math
         extractor produces for ``.. math:: :label: foo`` blocks.
+
+        Takes text rather than a node because docstrings are not the only
+        place documentation prose lives — ``#:`` attribute comments carry
+        the same roles and are invisible to ``ast`` entirely.
         """
-        docstring = ast.get_docstring(node)
-        if not docstring:
-            return
 
         # Equation labels DEFINED in this docstring (``.. math::``
         # with ``:label:``). Emitted as concrete equation nodes so
@@ -966,15 +1049,31 @@ class CodeVisitor(ast.NodeVisitor):
             source=parent_id, target=binding_id, type=EdgeType.CONTAINS,
             metadata={"source": "ast"},
         ))
+        self._attach_attr_comment(binding_id, lineno)
+
+    def _attach_attr_comment(self, binding_id: str, lineno: int) -> None:
+        """Hang a ``#:`` comment block's prose on the binding it documents.
+
+        The references inside it are indistinguishable from docstring
+        references once extracted, so they go through the same path.
+        """
+        prose = self._attr_comments.get(lineno)
+        if prose:
+            self._add_text_refs(prose, binding_id)
 
     def _emit_instance_attribute(
-        self, cls_qname: str, name: str, lineno: int,
+        self,
+        cls_qname: str,
+        name: str,
+        lineno: int,
+        annotation: str | None = None,
     ) -> None:
         """Emit an ATTRIBUTE node for a ``self.<name>`` binding.
 
         Same node namespace as class-level bindings, so an annotated
         declaration and the ``__init__`` assignment collapse into one
-        node.
+        node. Also used for ``Cls.attr = ...`` bound after the class
+        body, which lands in the same namespace for the same reason.
         """
         attr_id = self._node_id("attribute", f"{cls_qname}.{name}")
         if attr_id in self._bindings_emitted:
@@ -987,6 +1086,8 @@ class CodeVisitor(ast.NodeVisitor):
         }
         if self._is_test_file:
             meta["is_test"] = True
+        if annotation:
+            meta["annotation"] = annotation
         self.nodes.append(GraphNode(
             id=attr_id,
             type=NodeType.ATTRIBUTE,
@@ -1001,18 +1102,63 @@ class CodeVisitor(ast.NodeVisitor):
             type=EdgeType.CONTAINS,
             metadata={"source": "ast"},
         ))
+        self._attach_attr_comment(attr_id, lineno)
+
+    def _emit_post_class_attribute(
+        self,
+        target: ast.expr,
+        lineno: int,
+        annotation: str | None = None,
+    ) -> bool:
+        """Bind ``Cls.attr = ...`` written after the class body.
+
+        The standard way to build enum-like singletons on a non-Enum
+        class, and how a lot of code registers defaults and sentinels::
+
+            @dataclass(frozen=True)
+            class BC:
+                kind: str
+
+            BC.vacuum = BC("vacuum")      # type: ignore[attr-defined]
+
+        These are real class attributes at import time — autodoc picks
+        them up and ``:data:`BC.vacuum``` renders as a working link — but
+        the class body holds no trace of them, so the graph reported
+        every such reference as dead. The ``type: ignore`` markers are a
+        good tell: the author already knows static tools cannot see it.
+
+        Returns True when the target was handled as a class attribute.
+        """
+        if not isinstance(target, ast.Attribute):
+            return False
+        owner = target.value
+        if not isinstance(owner, ast.Name):
+            return False
+        cls_qname = self._classes_defined.get(owner.id)
+        if cls_qname is None:
+            return False
+        self._emit_instance_attribute(
+            cls_qname, target.attr, lineno, annotation=annotation,
+        )
+        return True
 
     def visit_Assign(self, node: ast.Assign) -> None:
         for tgt in node.targets:
+            if self._emit_post_class_attribute(tgt, node.lineno):
+                continue
             for name in _iter_name_targets(tgt):
                 self._emit_binding(name, node.lineno)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        try:
+            annotation = ast.unparse(node.annotation)
+        except Exception:
+            annotation = None
+        if self._emit_post_class_attribute(
+            node.target, node.lineno, annotation=annotation,
+        ):
+            return
         if isinstance(node.target, ast.Name):
-            try:
-                annotation = ast.unparse(node.annotation)
-            except Exception:
-                annotation = None
             self._emit_binding(
                 node.target.id, node.lineno, annotation=annotation,
             )
@@ -1021,6 +1167,11 @@ class CodeVisitor(ast.NodeVisitor):
         self._scope.append(node.name)
         qname = self._qualified_name
         class_id = self._node_id("class", qname)
+        # Register before visiting the body so a later ``Cls.attr = ...``
+        # can find it. Only top-level classes are addressable by a bare
+        # name at module scope, which is the form this binds.
+        if self._class_depth == 0:
+            self._classes_defined[node.name] = qname
 
         class_meta: dict[str, object] = {
             "file_path": self._file_path,
@@ -1383,7 +1534,10 @@ def analyze_directory(
 
         module_name = resolver.file_to_module(filepath)
         is_test_file = any(fnmatch(rel, pat) for pat in test_patterns)
-        visitor = CodeVisitor(module_name, str(filepath), is_test_file=is_test_file)
+        visitor = CodeVisitor(
+            module_name, str(filepath), is_test_file=is_test_file,
+            attr_comments=attribute_comments(source),
+        )
         visitor.visit(tree)
 
         for node in visitor.nodes:

--- a/tests/test_dead_references.py
+++ b/tests/test_dead_references.py
@@ -1035,3 +1035,214 @@ def test_namespace_walk_ignores_documenting_doc_pages():
     _phantom_ref(kg, "py:method:pkg.alpha.Solver.apply", "py:function:apply",
                  "apply")
     assert _resolve_relative_references(kg) == 1
+# Attributes bound after the class body (issue #40)
+# ---------------------------------------------------------------------------
+#
+# The standard way to build enum-like singletons on a non-Enum class.
+# They are real class attributes at import time — autodoc documents them
+# and `:data:`BC.vacuum`` renders as a working link — but the class body
+# holds no trace, so every such reference was reported dead. 6 of the 7
+# findings remaining on ORPHEUS after #36 were this one shape.
+
+
+def test_post_class_body_attribute_is_indexed(tmp_path):
+    graph = _analyze_source(
+        tmp_path,
+        "from dataclasses import dataclass\n"
+        "\n"
+        "@dataclass(frozen=True)\n"
+        "class BC:\n"
+        "    kind: str\n"
+        "\n"
+        "BC.vacuum = BC('vacuum')          # type: ignore[attr-defined]\n"
+        "BC.reflective = BC('reflective')  # type: ignore[attr-defined]\n",
+    )
+    g = graph.nxgraph
+    for attr in ("kind", "vacuum", "reflective"):
+        nid = f"py:attribute:pkg.mod.BC.{attr}"
+        assert nid in g, f"{attr} missing"
+        assert g.nodes[nid]["type"] == NodeType.ATTRIBUTE.value
+    # Bound to the class, not left floating at module scope.
+    children = {
+        t for _, t, d in g.out_edges("py:class:pkg.mod.BC", data=True)
+        if d.get("type") == EdgeType.CONTAINS.value
+    }
+    assert "py:attribute:pkg.mod.BC.vacuum" in children
+    assert "py:data:pkg.mod.BC.vacuum" not in g
+
+
+def test_post_class_attribute_carries_annotation(tmp_path):
+    graph = _analyze_source(
+        tmp_path,
+        "class Reg:\n"
+        "    pass\n"
+        "\n"
+        "Reg.default: 'Reg' = Reg()\n",
+    )
+    node = graph.nxgraph.nodes["py:attribute:pkg.mod.Reg.default"]
+    assert node["annotation"] == "'Reg'"
+
+
+def test_attribute_on_imported_module_is_not_claimed(tmp_path):
+    """``mod.CONST = 1`` is somebody else's namespace.
+
+    Only classes defined in THIS module are extended — otherwise
+    monkey-patching an import would forge attributes onto a foreign
+    symbol the graph does not own.
+    """
+    graph = _analyze_source(
+        tmp_path,
+        "import os\n"
+        "\n"
+        "class Local:\n"
+        "    pass\n"
+        "\n"
+        "os.environ = {}\n"
+        "Local.ok = 1\n",
+    )
+    g = graph.nxgraph
+    assert "py:attribute:pkg.mod.Local.ok" in g
+    assert not any("environ" in str(n) for n in g)
+
+
+def test_post_class_attribute_rescues_the_reference(tmp_path):
+    """End to end: the reference stops being reported dead."""
+    graph = _analyze_source(
+        tmp_path,
+        "class BC:\n"
+        '    """Boundary tags.\n'
+        "\n"
+        "    See :data:`pkg.mod.BC.vacuum` and :data:`pkg.mod.BC.gone`.\n"
+        '    """\n'
+        "\n"
+        "BC.vacuum = BC()\n",
+    )
+    dead = {d.target_name for d in GraphQuery(graph).dead_references().dead}
+    assert "pkg.mod.BC.vacuum" not in dead
+    assert "pkg.mod.BC.gone" in dead
+
+
+def test_nested_class_attribute_binding_is_not_forged(tmp_path):
+    """Only top-level classes are addressable by a bare name."""
+    graph = _analyze_source(
+        tmp_path,
+        "class Outer:\n"
+        "    class Inner:\n"
+        "        pass\n"
+        "\n"
+        "Outer.tag = 1\n",
+    )
+    g = graph.nxgraph
+    assert "py:attribute:pkg.mod.Outer.tag" in g
+    # `Inner` is not bindable as a bare name at module scope.
+    assert "py:attribute:pkg.mod.Outer.Inner.x" not in g
+
+
+# ---------------------------------------------------------------------------
+# `#:` attribute comments and the :numref: crosswalk (issue #38)
+# ---------------------------------------------------------------------------
+
+
+def test_attribute_comment_block_references_are_extracted(tmp_path):
+    """`#:` prose carries real cross-references and `ast` drops it."""
+    graph = _analyze_source(
+        tmp_path,
+        "class FaceLayout:\n"
+        "    pass\n"
+        "\n"
+        "#: The axis crosswalk that :class:`pkg.mod.FaceLayout` keys on.\n"
+        "#: Continued on a second line, citing :func:`pkg.mod.absent`.\n"
+        "AXIS_NAMES = ('x', 'y', 'z')\n",
+    )
+    g = graph.nxgraph
+    targets = {t for _, t, d in g.out_edges("py:data:pkg.mod.AXIS_NAMES", data=True)
+               if d.get("type") == EdgeType.REFERENCES.value}
+    assert "py:class:pkg.mod.FaceLayout" in targets
+    assert "py:function:pkg.mod.absent" in targets
+
+
+def test_attribute_comment_uses_tokens_not_a_line_regex(tmp_path):
+    """A `#:` inside a string literal is not an attribute comment.
+
+    The issue asked for `tokenize` over a line regex precisely for this.
+    """
+    graph = _analyze_source(
+        tmp_path,
+        "class Thing:\n"
+        "    pass\n"
+        "\n"
+        "TEMPLATE = 'prefix #: :class:`pkg.mod.Thing` suffix'\n"
+        "\n"
+        "PLAIN = 1  # :class:`pkg.mod.Thing` in an ordinary comment\n",
+    )
+    g = graph.nxgraph
+    for nid in ("py:data:pkg.mod.TEMPLATE", "py:data:pkg.mod.PLAIN"):
+        refs = {t for _, t, d in g.out_edges(nid, data=True)
+                if d.get("type") == EdgeType.REFERENCES.value}
+        assert not refs, f"{nid} picked up a non-attribute comment"
+
+
+def test_trailing_attribute_comment_documents_its_own_line(tmp_path):
+    graph = _analyze_source(
+        tmp_path,
+        "class Thing:\n"
+        "    pass\n"
+        "\n"
+        "LIMIT = 10  #: capped by :class:`pkg.mod.Thing`\n",
+    )
+    targets = {t for _, t, d in graph.nxgraph.out_edges(
+        "py:data:pkg.mod.LIMIT", data=True)
+        if d.get("type") == EdgeType.REFERENCES.value}
+    assert "py:class:pkg.mod.Thing" in targets
+
+
+def test_attribute_comment_citing_an_instance_attribute_is_not_dead(tmp_path):
+    """The ordering hazard #38 documents, verified.
+
+    PEP 526 records ``self.x: T`` nowhere at runtime — it is function-local
+    and discarded — so an import-based checker sees no such attribute and
+    calls this reference dead. An AST indexer has the ``AnnAssign`` right
+    there, which is why widening the scanned surface is safe HERE and was
+    not safe in the consumer-side tool.
+    """
+    graph = _analyze_source(
+        tmp_path,
+        "class SNMesh:\n"
+        "    def __init__(self):\n"
+        "        self.bc: dict = {}\n"
+        "\n"
+        "#: Keyed on :attr:`pkg.mod.SNMesh.bc`.\n"
+        "AXIS_NAMES = ('x',)\n",
+    )
+    dead = {d.target_name for d in GraphQuery(graph).dead_references().dead}
+    assert "pkg.mod.SNMesh.bc" not in dead
+
+
+def test_numref_crosswalks_to_the_equation(tmp_path):
+    """`:numref:`label`` on an equation names the same target as `:eq:`."""
+    from sphinxcontrib.nexus._mappings import resolve_target_id
+
+    kg = KnowledgeGraph()
+    kg.add_node(GraphNode(id="math:equation:peierls-3d", type=NodeType.EQUATION,
+                          name="peierls-3d", display_name="peierls-3d",
+                          domain="math"))
+    assert resolve_target_id(
+        kg.nxgraph, None, "std", "numref", "peierls-3d",
+    ) == "math:equation:peierls-3d"
+
+
+def test_numref_does_not_hijack_non_equation_targets():
+    """The crosswalk fires only when the equation actually exists.
+
+    ``:numref:`fig-mesh``` names a figure. It did not resolve before this
+    change and still does not (figures live in the std-label namespace,
+    which is separate work) — what matters is that it is not silently
+    bound to a fabricated equation node.
+    """
+    from sphinxcontrib.nexus._mappings import resolve_target_id
+
+    kg = KnowledgeGraph()
+    kg.add_node(GraphNode(id="std:label:fig-mesh", type=NodeType.SECTION,
+                          name="fig-mesh", display_name="fig-mesh", domain="std"))
+    resolved = resolve_target_id(kg.nxgraph, None, "std", "numref", "fig-mesh")
+    assert resolved != "math:equation:fig-mesh"


### PR DESCRIPTION
Closes #40. Closes #38.

Landed together because #38 documents the ordering hazard between them: widening the scanned reference surface *before* the indexer can see an attribute manufactures false dead references. Splitting these would have shipped a regression in between.

## #40 — attributes bound after the class body

`_iter_name_targets` deliberately skips `ast.Attribute` targets, so the standard enum-like-singleton idiom was invisible:

```python
@dataclass(frozen=True)
class BC:
    kind: str

BC.vacuum = BC("vacuum")   # type: ignore[attr-defined]
```

Real class attributes at import time — autodoc documents them, ``:data:`BC.vacuum``` renders as a working link — but the class body holds no trace, so every reference was reported dead. **6 of the 7 findings remaining on ORPHEUS after #36 were this one shape.**

Bound only for classes defined in *this* module. `os.environ = {}` is somebody else's namespace, and forging attributes onto a foreign symbol is how the graph would start lying about code it does not own.

## #38 — `#:` attribute comments

`ast` discards comments outright, so the token stream is the only way to see them. **`tokenize`, not a line regex**, as the issue asked — a `#:` inside a string literal is not an attribute comment, and that is tested. Handles the leading-block form and the trailing `x = 1  #: doc` form.

Role extraction moved out of `_add_docstring_refs` into `_add_text_refs`: docstrings are not the only place documentation prose lives.

## #38 — `:numref:` crosswalk

``:numref:`peierls-3d``` on an equation label names the same target as ``:eq:``. It was minting a `math:numref:` placeholder beside the real equation node, splitting one equation's references across two ids. Guarded by an existence check so a figure reference cannot fabricate an equation.

**Deliberately not fixed:** `:numref:` to figures and tables still does not resolve. It never did. Those live in the std-label namespace and want their own measurement rather than a guess bolted onto this.

## The ordering hazard, verified rather than assumed

```
#: Keyed on :attr:`pkg.mod.SNMesh.bc`.   →  binds to the real attribute ✓
#: Also :func:`pkg.mod.gone`.            →  stays a phantom ✓
```

PEP 526 records `self.bc: dict` **nowhere** at runtime — function-local and discarded — so an import-based checker sees no such attribute and calls the reference dead. Nexus has the `AnnAssign` right there. That asymmetry is the argument for doing this work here, and it only holds if the attribute indexing lands first.

## Results — ORPHEUS

This branch alone: dead references **7 → 1**, zero new findings.

Combined with #43 (built locally, both branches merged): **14 → 0**.

Zero is the kind of number that deserves suspicion, so the gate was checked rather than trusted:

| | |
|---|---|
| unresolved py nodes still in the graph | 4,115 |
| unresolved nodes referenced from doc pages | 196 |
| findings on the clean graph | 0 |
| findings after injecting one synthetic dead reference | **1** (caught) |

The gate has input and still detects. It reports nothing because there is nothing left to report.

## Tests

11 new. 656 pass on this branch, 663 combined with #43. pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
