### PR TITLE
refactor(merge): reconcile once post-merge; name the code that minted a phantom (#46, #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,30 @@ Tested against a real `sphinx-proof` build (`tests/roots/test-proof-relations`)
 rather than a fixture guess, since the whole point is what the upstream
 extension actually publishes. `sphinx-proof` is now a test-only dependency.
 
+### Changed — reconciliation decides once, over the whole graph (#46)
+
+`merge_graphs` runs once per source directory, and unresolved-node
+reconciliation lived inside it — a decision needing project-wide knowledge,
+taken from a single slice. The previous fix widened its index to span both
+graphs, which repaired the observed binding but left the failure mode: a rival
+arriving in a *later* slice could not retroactively make an earlier decision
+ambiguous. It was safe only because ORPHEUS merges its main tree first.
+
+Now `merge.reconcile_unresolved(graph)`, called once after every merge in both
+the Sphinx and CLI paths. `merge_graphs` is a pure merge again.
+
+### Added — dead references name the code that minted them (#39)
+
+`DeadReference.minted_by` lists the source files whose own code — an import,
+call, annotation, or base class — created a placeholder. Non-empty means the
+target is not simply absent: it exists as a name only because those files
+reference it, and a role elsewhere then bound to it. When they sit in one
+unmaintained corner of the tree, that directory is the finding rather than the
+reference.
+
+Prose does not count as minting. A page mentioning a vanished symbol is the
+reference being reported, not its cause.
+
 ### Added — relative references resolve against their namespace (#37)
 
 Half of a real project's Python references are relative —

--- a/sphinxcontrib/nexus/__init__.py
+++ b/sphinxcontrib/nexus/__init__.py
@@ -205,6 +205,7 @@ def _run_ast_analysis(app: Sphinx, graph: Any) -> None:
     from sphinxcontrib.nexus.directives import apply_pending_edges
     from sphinxcontrib.nexus.merge import (
         _infer_implements,
+        reconcile_unresolved,
         write_verifies_edges,
     )
     from sphinxcontrib.nexus.registry import (
@@ -222,6 +223,10 @@ def _run_ast_analysis(app: Sphinx, graph: Any) -> None:
     # — it reproduces what Sphinx itself would link — while leaf-matching
     # is a guess among same-named candidates. An answer must not lose to
     # a guess that happens to sort first.
+    # Reconciliation decides against the COMPLETE graph, not the last
+    # slice merged — see ``reconcile_unresolved`` for the wrong binding
+    # that the per-directory version produced.
+    reconcile_unresolved(graph)
     _resolve_relative_references(graph)
     _canonicalize_phantoms(graph)
 

--- a/sphinxcontrib/nexus/cli.py
+++ b/sphinxcontrib/nexus/cli.py
@@ -1196,7 +1196,7 @@ def _run_setup(args: argparse.Namespace) -> int:
 def _run_analyze(args: argparse.Namespace) -> int:
     from sphinxcontrib.nexus.ast_analyzer import analyze_directory
     from sphinxcontrib.nexus.export import load_sqlite, write_json, write_sqlite
-    from sphinxcontrib.nexus.merge import merge_graphs
+    from sphinxcontrib.nexus.merge import merge_graphs, reconcile_unresolved
 
     source_dir = args.source_dir.resolve()
     if not source_dir.is_dir():
@@ -1216,6 +1216,9 @@ def _run_analyze(args: argparse.Namespace) -> int:
     if args.db.exists():
         sphinx_graph = load_sqlite(args.db)
         merged = merge_graphs(sphinx_graph, ast_graph)
+        # merge_graphs no longer reconciles — that decision needs the
+        # whole graph, which here is everything merged above.
+        reconcile_unresolved(merged)
         print(f"Merged with existing graph from {args.db}")
     else:
         merged = ast_graph
@@ -1564,6 +1567,14 @@ def _run_dead_references(args: argparse.Namespace) -> int:
             print(f"      {site.source.id}{f'  ({where}{line})' if where else ''}")
         if entry.site_count > 4:
             print(f"      … and {entry.site_count - 4} more")
+        if entry.minted_by:
+            # The target is not simply absent — this code names it, and a
+            # reference elsewhere bound to the placeholder that created.
+            # When these all sit in one unmaintained corner of the tree,
+            # that directory is the finding, not the reference.
+            print("      minted by code in:")
+            for path in entry.minted_by:
+                print(f"        {path}")
     if result.total_dead > len(dead):
         print(f"\n  … and {result.total_dead - len(dead)} more target(s)")
     return 1 if args.exit_code else 0

--- a/sphinxcontrib/nexus/merge.py
+++ b/sphinxcontrib/nexus/merge.py
@@ -71,81 +71,6 @@ def merge_graphs(
             attrs["source"] = "ast_only"
             sg.add_node(node_id, **attrs)
 
-    # Step 4: reconcile UNRESOLVED nodes
-    #
-    # Index every candidate under both its full and its short name. Names
-    # collide — three real modules can share the leaf ``derivations`` —
-    # so each key holds every candidate and the winner is chosen by the
-    # shared ranking, not by whichever node the walk happened to reach
-    # last. This pass rewires edges, so an ambiguous name is declined
-    # rather than guessed: silently reattributing a reference to the
-    # wrong symbol is worse than leaving it unresolved, where
-    # ``dead_references`` will at least surface it.
-    #
-    # The index spans BOTH graphs, and that is load-bearing.
-    # ``merge_graphs`` runs once per source directory, so the incoming
-    # ``ag`` is one slice of the project — a name with rivals elsewhere
-    # looks unique inside it. ORPHEUS merges ``tests`` after the main
-    # tree, and indexing ``ag`` alone bound a docstring's bare
-    # ``:mod:`derivations``` to the TEST package: unambiguous within the
-    # slice, wrong across the project. Candidates already folded into
-    # ``sg`` by earlier passes have to compete too.
-    by_name: dict[str, list[tuple[str, str]]] = {}
-    seen_ids: set[str] = set()
-    for graph_view in (ag, sg):
-        for node_id, attrs in graph_view.nodes(data=True):
-            if node_id in seen_ids:
-                continue
-            name = attrs.get("name", "")
-            if not name or attrs.get("type") == NodeType.UNRESOLVED.value:
-                continue
-            seen_ids.add(node_id)
-            by_name.setdefault(name.rsplit(".", 1)[-1], []).append(
-                (node_id, name),
-            )
-            by_name.setdefault(name, []).append((node_id, name))
-
-    def _attrs_of(cid: str) -> dict:
-        return ag.nodes[cid] if cid in ag else sg.nodes[cid]
-
-    def _best_match(name: str) -> str | None:
-        candidates = by_name.get(name)
-        if not candidates:
-            return None
-        ranked = sorted(
-            candidate_rank(cid, cname, _attrs_of(cid))
-            for cid, cname in candidates
-        )
-        if candidates_are_ambiguous(ranked):
-            return None
-        return ranked[0][-1]
-
-    unresolved_to_remove: list[str] = []
-    for node_id, attrs in list(sg.nodes(data=True)):
-        if attrs.get("type") != NodeType.UNRESOLVED.value:
-            continue
-        name = attrs.get("name", "")
-        # Try to find a concrete AST node matching this name
-        concrete_id = _best_match(name)
-        if concrete_id and concrete_id in sg and concrete_id != node_id:
-            # Retarget all edges pointing to the unresolved node
-            for src, _, key, data in list(sg.in_edges(node_id, keys=True, data=True)):
-                sg.add_edge(src, concrete_id, **data)
-                sg.remove_edge(src, node_id, key=key)
-            for _, tgt, key, data in list(sg.out_edges(node_id, keys=True, data=True)):
-                sg.add_edge(concrete_id, tgt, **data)
-                sg.remove_edge(node_id, tgt, key=key)
-            unresolved_to_remove.append(node_id)
-
-    for node_id in unresolved_to_remove:
-        sg.remove_node(node_id)
-
-    if unresolved_to_remove:
-        logger.info(
-            "Reconciled %d UNRESOLVED nodes with AST-found symbols",
-            len(unresolved_to_remove),
-        )
-
     # Step 5: copy all AST edges
     for src, tgt, _key, data in ag.edges(keys=True, data=True):
         sg.add_edge(src, tgt, **data)
@@ -157,6 +82,81 @@ def merge_graphs(
     _tag_confidence(sg)
 
     return sphinx_kg
+
+
+
+def reconcile_unresolved(graph: KnowledgeGraph) -> int:
+    """Fold UNRESOLVED nodes onto the real definitions that share a name.
+
+    Runs ONCE over the complete graph, on purpose. This used to live
+    inside :func:`merge_graphs`, which is called once per source
+    directory — so it judged "is this name ambiguous?" against a single
+    slice of the project, and a name with rivals elsewhere looked
+    unique inside it. ORPHEUS merges ``tests`` after the main tree, and
+    a docstring's bare ``:mod:`derivations``` bound to the TEST package:
+    unambiguous within the slice that decided it, wrong across the
+    project.
+
+    Widening the index to span both graphs fixed the observed case but
+    left the pass order-sensitive by construction — a rival arriving in
+    a LATER slice still could not retroactively make an earlier decision
+    ambiguous. Deciding after every merge removes the failure mode
+    rather than narrowing it.
+
+    Names are indexed under both their full and their short form, every
+    candidate competes under the shared ranking, and an ambiguous name
+    is declined: this rewires edges, and silently reattributing a
+    reference to the wrong symbol is worse than leaving it unresolved,
+    where ``dead_references`` will surface it.
+
+    Returns the number of nodes folded away.
+    """
+    g = graph.nxgraph
+
+    by_name: dict[str, list[tuple[str, str]]] = {}
+    for node_id, attrs in g.nodes(data=True):
+        name = attrs.get("name", "")
+        if not name or attrs.get("type") == NodeType.UNRESOLVED.value:
+            continue
+        by_name.setdefault(name.rsplit(".", 1)[-1], []).append((node_id, name))
+        by_name.setdefault(name, []).append((node_id, name))
+
+    def _best_match(name: str) -> str | None:
+        candidates = by_name.get(name)
+        if not candidates:
+            return None
+        ranked = sorted(
+            candidate_rank(cid, cname, g.nodes[cid])
+            for cid, cname in candidates
+        )
+        if candidates_are_ambiguous(ranked):
+            return None
+        return ranked[0][-1]
+
+    folded: list[str] = []
+    for node_id, attrs in list(g.nodes(data=True)):
+        if attrs.get("type") != NodeType.UNRESOLVED.value:
+            continue
+        concrete_id = _best_match(attrs.get("name", ""))
+        if not concrete_id or concrete_id == node_id or concrete_id not in g:
+            continue
+        for src, _, key, data in list(g.in_edges(node_id, keys=True, data=True)):
+            g.add_edge(src, concrete_id, **data)
+            g.remove_edge(src, node_id, key=key)
+        for _, tgt, key, data in list(g.out_edges(node_id, keys=True, data=True)):
+            g.add_edge(concrete_id, tgt, **data)
+            g.remove_edge(node_id, tgt, key=key)
+        folded.append(node_id)
+
+    for node_id in folded:
+        g.remove_node(node_id)
+
+    if folded:
+        logger.info(
+            "Reconciled %d UNRESOLVED nodes with AST-found symbols",
+            len(folded),
+        )
+    return len(folded)
 
 
 def _tag_confidence(g: "nx.MultiDiGraph") -> None:

--- a/sphinxcontrib/nexus/query.py
+++ b/sphinxcontrib/nexus/query.py
@@ -465,6 +465,13 @@ class DeadReference:
     kind: str  # "python" | "equation"
     site_count: int
     sites: list[DeadReferenceSite]
+    #: Source files whose own code (an import, call, or annotation)
+    #: minted this placeholder. Non-empty means the target is not simply
+    #: absent — it exists as a name only because these files reference
+    #: it, and a bare role elsewhere then bound to it. When they all sit
+    #: in one unmaintained corner of the tree, that directory is the
+    #: finding, not the reference. See ``minting_files``.
+    minted_by: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -2025,6 +2032,51 @@ class GraphQuery:
         "abc.ABC",
     })
 
+    #: Edge kinds that mean "this file's own code names the target",
+    #: as opposed to prose that merely mentions it. An import or a call
+    #: is what MINTS a placeholder; a doc reference only consumes one.
+    _MINTING_EDGE_TYPES: frozenset[str] = frozenset({
+        "imports", "calls", "type_uses", "inherits",
+    })
+
+    def _minting_files(self, target_id: str, limit: int = 5) -> list[str]:
+        """Source files whose code created this placeholder.
+
+        The ORPHEUS shape behind #36: a prototyping directory still
+        imported a module retired months earlier, so nexus minted
+        placeholder nodes for the unresolvable path — and bare
+        ``:func:`name``` roles on unrelated theory pages then bound to
+        them. Live symbols were reported dead against a namespace only a
+        throwaway prototype defined.
+
+        Ranking (#41/#42) stopped a placeholder from outranking a real
+        definition, so that specific harm is gone. What remains worth
+        surfacing is the weaker case: the placeholder is the ONLY match,
+        the reference is genuinely reported dead, and the reason is that
+        some corner of the tree names a symbol nothing defines. Pointing
+        at those files turns "this reference is dead" into "this
+        directory is minting a namespace", which is the actionable form.
+
+        Empty when nothing in the codebase names the target — then it is
+        simply absent, which is ordinary drift.
+        """
+        g = self._g
+        if target_id not in g:
+            return []
+        files: list[str] = []
+        seen: set[str] = set()
+        for src, _, data in g.in_edges(target_id, data=True):
+            if data.get("type") not in self._MINTING_EDGE_TYPES:
+                continue
+            path = (g.nodes.get(src) or {}).get("file_path")
+            if not path or path in seen:
+                continue
+            seen.add(path)
+            files.append(path)
+            if len(files) >= limit:
+                break
+        return sorted(files)
+
     def dead_references(
         self, max_sites_per_target: int = 25,
     ) -> DeadReferencesResult:
@@ -2136,6 +2188,7 @@ class GraphQuery:
                 kind=kinds[tgt],
                 site_count=len(sites),
                 sites=sites[:max_sites_per_target],
+                minted_by=self._minting_files(tgt),
             ))
 
         dead.sort(key=lambda d: (-d.site_count, d.target_name))

--- a/tests/test_dead_references.py
+++ b/tests/test_dead_references.py
@@ -1246,3 +1246,77 @@ def test_numref_does_not_hijack_non_equation_targets():
                           name="fig-mesh", display_name="fig-mesh", domain="std"))
     resolved = resolve_target_id(kg.nxgraph, None, "std", "numref", "fig-mesh")
     assert resolved != "math:equation:fig-mesh"
+
+
+# ---------------------------------------------------------------------------
+# Placeholder provenance (issue #39)
+# ---------------------------------------------------------------------------
+#
+# The ORPHEUS shape behind #36: a prototyping directory still imported a
+# module retired months earlier, so nexus minted placeholders for the
+# unresolvable path — and bare roles on unrelated theory pages bound to
+# them. Ranking (#41/#42) stopped a placeholder from beating a real
+# definition, so that harm is gone. What is still worth surfacing is the
+# weaker case: the placeholder is the only match, the reference IS dead,
+# and the reason is that some corner of the tree names a symbol nothing
+# defines. Naming those files turns "this reference is dead" into "this
+# directory is minting a namespace".
+
+
+def _minting_fixture() -> KnowledgeGraph:
+    kg = KnowledgeGraph()
+    kg.add_node(GraphNode(id="doc:page", type=NodeType.FILE, name="page",
+                          display_name="page", domain="std", docname="page"))
+    # A prototype module that still imports something retired. Its
+    # file_path is what makes ``proj`` a project-owned top level, so the
+    # phantom below is project-internal rather than external.
+    _node(kg, "py:module:proj.scratch.probe", NodeType.MODULE,
+          "proj.scratch.probe", file_path="/proj/scratch/probe.py")
+    _node(kg, "py:function:proj.retired.compute", NodeType.UNRESOLVED,
+          "proj.retired.compute")
+    kg.add_edge(GraphEdge(source="py:module:proj.scratch.probe",
+                          target="py:function:proj.retired.compute",
+                          type=EdgeType.IMPORTS))
+    # A theory page references it too — this is the reported site.
+    kg.add_edge(GraphEdge(source="doc:page",
+                          target="py:function:proj.retired.compute",
+                          type=EdgeType.DOCUMENTS, metadata={"reftype": "func"}))
+    return kg
+
+
+def test_dead_reference_names_the_code_that_minted_it():
+    result = GraphQuery(_minting_fixture()).dead_references()
+    entry = next(d for d in result.dead
+                 if d.target_name == "proj.retired.compute")
+    assert entry.minted_by == ["/proj/scratch/probe.py"]
+
+
+def test_ordinary_drift_has_no_minting_files():
+    """A symbol nothing names is simply absent — that is normal drift."""
+    kg = KnowledgeGraph()
+    kg.add_node(GraphNode(id="doc:page", type=NodeType.FILE, name="page",
+                          display_name="page", domain="std", docname="page"))
+    _node(kg, "py:module:proj.live", NodeType.MODULE, "proj.live",
+          file_path="/proj/live.py")
+    _node(kg, "py:class:proj.Gone", NodeType.UNRESOLVED, "proj.Gone")
+    kg.add_edge(GraphEdge(source="doc:page", target="py:class:proj.Gone",
+                          type=EdgeType.DOCUMENTS, metadata={"reftype": "class"}))
+    entry = next(d for d in GraphQuery(kg).dead_references().dead
+                 if d.target_name == "proj.Gone")
+    assert entry.minted_by == []
+
+
+def test_prose_references_do_not_count_as_minting():
+    """Only code that NAMES the target mints it.
+
+    A doc page mentioning a vanished symbol is the reference being
+    reported, not the cause of it — counting prose would make every
+    finding look self-inflicted.
+    """
+    kg = _minting_fixture()
+    kg.add_edge(GraphEdge(source="doc:page",
+                          target="py:function:proj.retired.compute",
+                          type=EdgeType.REFERENCES))
+    entry = next(d for d in GraphQuery(kg).dead_references().dead
+                 if d.target_name == "proj.retired.compute")
+    assert entry.minted_by == ["/proj/scratch/probe.py"]

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -12,6 +12,7 @@ from sphinxcontrib.nexus.graph import (
 from sphinxcontrib.nexus.merge import (
     _infer_implements,
     merge_graphs,
+    reconcile_unresolved,
     write_verifies_edges,
 )
 
@@ -110,6 +111,7 @@ def test_merge_reconciles_unresolved():
     sphinx = _make_sphinx_graph()
     ast_g = _make_ast_graph()
     merged = merge_graphs(sphinx, ast_g)
+    reconcile_unresolved(merged)
     # UNRESOLVED CPMesh should be gone
     assert "py:class:solver:CPMesh" not in merged.nxgraph
     # Concrete node should exist
@@ -440,6 +442,7 @@ def _ambiguous_pair() -> tuple[KnowledgeGraph, KnowledgeGraph]:
 
 def test_ambiguous_short_name_is_left_unresolved():
     merged = merge_graphs(*_ambiguous_pair())
+    reconcile_unresolved(merged)
     g = merged.nxgraph
     assert "py:module:derivations" in g, (
         "an ambiguous short name must stay unresolved and be reported, "
@@ -457,7 +460,9 @@ def test_unambiguous_short_name_still_reconciles():
     ast_g.nxgraph.remove_node("py:module:tests.derivations")
     ast_g.nxgraph.remove_node("py:module:pkg.deep.origins.derivations")
 
-    g = merge_graphs(sphinx, ast_g).nxgraph
+    merged = merge_graphs(sphinx, ast_g)
+    reconcile_unresolved(merged)
+    g = merged.nxgraph
     assert "py:module:derivations" not in g
     targets = {t for _, t, d in g.edges(data=True)
                if d.get("type") == EdgeType.REFERENCES.value}
@@ -481,23 +486,25 @@ def test_placeholder_never_wins_reconciliation():
         display_name="widget", domain="py",
         metadata={"file_path": "/pkg/__init__.py"},
     ))
-    g = merge_graphs(sphinx, ast_g).nxgraph
+    merged = merge_graphs(sphinx, ast_g)
+    reconcile_unresolved(merged)
+    g = merged.nxgraph
     assert "py:function:pkg.widget" in g
     assert "py:function:widget" not in g
 
 
-def test_ambiguity_is_judged_across_directories_not_within_one():
-    """The rival may arrive in a LATER merge pass.
+def test_ambiguity_is_judged_after_every_merge_not_during_one():
+    """Reconciliation decides once, against the complete graph.
 
-    ``merge_graphs`` runs once per source directory, so a name with
-    rivals elsewhere in the project looks unique inside any single
-    slice. The ORPHEUS shape: the main tree holds two same-leaf modules
-    (ambiguous — correctly declined), then the ``tests`` slice offers
-    exactly ONE candidate, and judged against that slice alone the bare
-    ``:mod:`derivations``` bound to the TEST package.
+    It used to run inside every ``merge_graphs`` call — once per source
+    directory — so it judged ambiguity against a single slice. Widening
+    the index to span both graphs fixed the observed ORPHEUS case but
+    left the order-sensitivity: a rival arriving in a LATER slice still
+    could not retroactively make an earlier decision ambiguous.
 
-    Nothing downstream can see that — the edge is well-formed and points
-    at a node that exists — so it is pinned here.
+    This is that case, and the previous fix could not catch it — the
+    rival module arrives only in pass 2, so any decision taken during
+    pass 1 is already wrong by the time it exists.
     """
     sphinx = KnowledgeGraph()
     sphinx.add_node(GraphNode(id="doc:page", type=NodeType.FILE, name="page",
@@ -509,35 +516,36 @@ def test_ambiguity_is_judged_across_directories_not_within_one():
     sphinx.add_edge(GraphEdge(source="doc:page", target="py:module:derivations",
                               type=EdgeType.REFERENCES))
 
-    # Pass 1 — the main tree offers two same-leaf modules, so the name
-    # is ambiguous here and reconciliation correctly declines.
-    main = KnowledgeGraph()
-    for full in ("pkg.derivations", "pkg.deep.origins.derivations"):
-        main.add_node(GraphNode(
-            id=f"py:module:{full}", type=NodeType.MODULE, name=full,
-            display_name="derivations", domain="py",
-            metadata={"file_path": f"/{full.replace('.', '/')}/__init__.py"},
-        ))
-    merged = merge_graphs(sphinx, main)
-    assert "py:module:derivations" in merged.nxgraph, (
-        "two same-leaf candidates in one slice must already decline"
-    )
+    def slice_with(*fulls):
+        kg = KnowledgeGraph()
+        for full in fulls:
+            kg.add_node(GraphNode(
+                id=f"py:module:{full}", type=NodeType.MODULE, name=full,
+                display_name="derivations", domain="py",
+                metadata={"file_path": f"/{full.replace('.', '/')}/__init__.py"},
+            ))
+        return kg
 
-    # Pass 2 — the tests dir offers exactly ONE candidate. Within this
-    # slice the name looks unique; only the accumulated graph knows it
-    # is not.
-    tests_g = KnowledgeGraph()
-    tests_g.add_node(GraphNode(
-        id="py:module:tests.derivations", type=NodeType.MODULE,
-        name="tests.derivations", display_name="derivations", domain="py",
-        metadata={"file_path": "/tests/derivations/__init__.py"},
-    ))
-    g = merge_graphs(merged, tests_g).nxgraph
+    # Pass 1 offers exactly ONE candidate — unambiguous in isolation.
+    merged = merge_graphs(sphinx, slice_with("pkg.derivations"))
+    # Pass 2 brings the rival that makes the name ambiguous.
+    merged = merge_graphs(merged, slice_with("tests.derivations"))
 
+    # Only now is the decision taken, and it sees both.
+    reconcile_unresolved(merged)
+
+    g = merged.nxgraph
     targets = {t for _, t, d in g.edges(data=True)
                if d.get("type") == EdgeType.REFERENCES.value}
-    assert "py:module:tests.derivations" not in targets, (
-        "a reference was silently rebound to the test package because "
-        "the later slice saw only its own candidate"
+    assert "py:module:pkg.derivations" not in targets, (
+        "pass 1 saw one candidate and would have folded; deciding after "
+        "every merge is what makes the rival visible"
     )
+    assert "py:module:tests.derivations" not in targets
     assert "py:module:derivations" in g
+
+
+def test_merge_graphs_no_longer_reconciles_on_its_own():
+    """The phase boundary is the point — pin it."""
+    merged = merge_graphs(*_ambiguous_pair())
+    assert "py:module:derivations" in merged.nxgraph


### PR DESCRIPTION
Closes #46. Addresses the open item on #39.

## #46 — reconciliation decides against the complete graph

`merge_graphs` runs once per source directory, and step 4 reconciled UNRESOLVED nodes inside it: a decision needing project-wide knowledge, taken from one slice.

#42 widened the index to span both graphs, which fixed the observed ORPHEUS binding but left the failure mode intact — **a rival arriving in a later slice cannot retroactively make an earlier decision ambiguous.** It was safe only because ORPHEUS happens to merge its main tree before its extra dirs.

Extracted to `reconcile_unresolved(graph)`, called once after every merge in both the Sphinx and CLI paths. `merge_graphs` is a pure merge again.

The late-rival case is pinned by a test — and I ran the **old** architecture against it to confirm the difference is real rather than assumed:

```
OLD (reconcile per pass) -> {'py:module:pkg.derivations'}
   folded prematurely: True
```

Pass 1 sees one candidate and folds; the rival only exists in pass 2. The previous fix could not have caught this.

## #39 — placeholder provenance

ORPHEUS asked for a signal when a placeholder minted from an unresolvable import becomes the sole match for a role. Ranking (#41/#42) already removed the case where such a placeholder *beat* a real definition. What remains is the weaker one: the placeholder is the only match, the reference is genuinely dead, and the cause is that some corner of the tree names a symbol nothing defines.

`DeadReference.minted_by` lists the source files whose own code — import, call, annotation, or base class — created the placeholder. **Prose does not count**: a page mentioning a vanished symbol is the reference being reported, not its cause, and counting it would make every finding look self-inflicted. Empty means ordinary drift.

Validated by re-creating the actual #36 shape on the live ORPHEUS graph:

```
  orpheus.derivations.peierls_geometry.compute_G_bc — 1 site(s)
     minted by code in: /Users/rodrigo/git/nuclear/ORPHEUS/scratch/derivations/probe.py
```

That turns "this reference is dead" into "this directory is minting a namespace", which is the actionable form — and is exactly the diagnosis that took manual investigation in #36.

## ORPHEUS

Dead references stay at **0**. Checked by target rather than by count: `derivations` still resolves to its sibling module, the five `BC` attributes are intact, and the 55 `orpheus.* → tests.*` reference edges spot-check as genuine V&V cross-references written fully qualified in the source.

Node count moved 23,793 → 23,439; reconciliation now sees the complete graph *and* all AST edges (it used to run before step 5 copied them), so it folds more.

## Not addressed

While spot-checking those 55 edges I noticed a few bare names leaf-matching into the **test tree** (e.g. an `AngularTraceSpace` docstring reaching a test helper's `HalfTraces.omega_dot_n`). That is pre-existing `_canonicalize_phantoms` behaviour, orthogonal to this PR, and I did not adjudicate all 55. Worth its own measured look if you want it.

## Tests

667 pass, pyright clean. 6 new: the late-rival case, the phase boundary itself, and three for `minted_by` including the prose-is-not-minting distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
