### PR TITLE
fix(resolve): stop test helpers absorbing production references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,33 @@ Tested against a real `sphinx-proof` build (`tests/roots/test-proof-relations`)
 rather than a fixture guess, since the whole point is what the upstream
 extension actually publishes. `sphinx-proof` is now a test-only dependency.
 
+### Fixed — test helpers no longer absorb production references
+
+Bare-name fuzzy matching is deliberately more permissive than Sphinx: an api
+page writing ``:class:`CPMesh``` with no `currentmodule` fails Sphinx's own
+lookup and renders as plain text, while nexus resolves it. That generosity
+recovers thousands of real doc-page-to-class links and is kept.
+
+The test tree is where it went wrong — test modules are full of short generic
+names, so they acted as a magnet for any bare name with no better candidate. On
+ORPHEUS a reactor-physics operator's ``:attr:`K``` bound to a test class's
+attribute, and ``record`` to `tests._harness.registry`. The direction is the
+discriminator: a test-tree candidate is refused for a phantom that anything
+outside the test tree references. Test-to-test references are untouched, and
+explicit fully-qualified references never create a phantom so are unaffected.
+
+Two supporting fixes: `is_test` was never set on test-tree nodes when the test
+root was itself the analysed source dir (patterns are project-relative, paths
+were source-dir-relative), and `merge_graphs` dropped the flag for any test
+symbol that was also autodoc'd. A new `in_test_file` marker answers "does this
+live in the test tree?", which is a different question from `is_test`'s "is this
+a test case?" — the latter is name-based and load-bearing for `retest` and
+`dead_functions`.
+
+This surfaced one true dead reference on ORPHEUS that leaf-matching had been
+hiding: a docstring naming `tests.sn.test_scattering_operator` after the module
+moved under `operators/`.
+
 ### Added — `:numref:` binds to figure and table labels (#45)
 
 `:numref:` names a target by its number rather than its title, but it names the

--- a/sphinxcontrib/nexus/_mappings.py
+++ b/sphinxcontrib/nexus/_mappings.py
@@ -197,6 +197,39 @@ def candidate_rank(
     )
 
 
+def test_node_is_off_limits(
+    nxgraph: "nx.MultiDiGraph", candidate_id: str, phantom_id: str,
+) -> bool:
+    """True when a test-tree node must not absorb this phantom.
+
+    Bare-name fuzzy matching is deliberately more permissive than
+    Sphinx: an api page writing ``:class:`CPMesh``` with no
+    ``currentmodule`` fails Sphinx's own lookup and renders as plain
+    text, while nexus resolves it. That generosity is worth keeping —
+    it recovers thousands of real doc-page-to-class links.
+
+    The test tree is where it goes wrong. Test modules are full of short
+    generic names (``K``, ``record``, ``slab``, ``omega_dot_n``), so
+    they act as a magnet for any bare name with no better candidate.
+    Measured on ORPHEUS: 578 bare references from production code landed
+    on test helpers — a reactor-physics operator's ``:attr:`K``` bound
+    to a test class's attribute.
+
+    Production code does not reference test helpers, so the direction is
+    the discriminator, not the name. Test-to-test bare references are
+    untouched; only a candidate inside the test tree, for a phantom that
+    something outside it references, is refused.
+    """
+    if not (nxgraph.nodes.get(candidate_id) or {}).get("in_test_file"):
+        return False
+    # The phantom is shared by every referrer that spelled the name, so
+    # one production referrer is enough to rule the candidate out.
+    return any(
+        not (nxgraph.nodes.get(src) or {}).get("in_test_file")
+        for src, _ in nxgraph.in_edges(phantom_id)
+    )
+
+
 def candidates_are_ambiguous(ranked: list[tuple[Any, ...]]) -> bool:
     """True when the top candidates are indistinguishable in kind.
 

--- a/sphinxcontrib/nexus/ast_analyzer.py
+++ b/sphinxcontrib/nexus/ast_analyzer.py
@@ -19,6 +19,7 @@ from sphinxcontrib.nexus._mappings import (
     PLACEHOLDER_TYPES,
     candidate_rank,
     candidates_are_ambiguous,
+    test_node_is_off_limits,
 )
 from sphinxcontrib.nexus.fingerprint import body_fingerprint
 from sphinxcontrib.nexus.graph import (
@@ -1519,6 +1520,10 @@ def analyze_directory(
         if nested_trees and not nested_trees.isdisjoint(filepath.parents):
             continue
         rel = filepath.relative_to(source_dir).as_posix()
+        try:
+            rel_to_root = filepath.relative_to(project_root).as_posix()
+        except ValueError:
+            rel_to_root = rel
         # Match exclude patterns against the relative POSIX path, not the
         # path tail (Path.match anchors to the right, which silently
         # skips nested matches for patterns like ``tests/*``).
@@ -1533,12 +1538,34 @@ def analyze_directory(
             continue
 
         module_name = resolver.file_to_module(filepath)
-        is_test_file = any(fnmatch(rel, pat) for pat in test_patterns)
+        # Test patterns are written project-relative (``tests/*``), but
+        # ``rel`` is relative to the SOURCE DIR — and when that dir is
+        # itself the test root (``nexus_extra_source_dirs = ['tests']``)
+        # the ``tests/`` prefix is gone, so ``tests/*`` cannot match and
+        # only the ``test_*.py`` filename patterns fire. Helper modules
+        # inside the test tree (``_harness/registry.py``, snapshot
+        # generators) were therefore never flagged: 2113 of ORPHEUS's
+        # test-tree nodes carried no ``is_test``. Match both spellings.
+        is_test_file = any(
+            fnmatch(rel, pat) or fnmatch(rel_to_root, pat)
+            for pat in test_patterns
+        )
         visitor = CodeVisitor(
             module_name, str(filepath), is_test_file=is_test_file,
             attr_comments=attribute_comments(source),
         )
         visitor.visit(tree)
+
+        if is_test_file:
+            # ``is_test`` means "this IS a test" — name-based for
+            # functions, so a helper like ``_harness.registry.record``
+            # never carries it, and ``retest`` / ``dead_functions``
+            # depend on that meaning. ``in_test_file`` is the different
+            # question — "does this live in the test tree?" — which is
+            # what fuzzy name matching needs in order not to let a test
+            # helper absorb a reference from production code.
+            for node in visitor.nodes:
+                node.metadata["in_test_file"] = True
 
         for node in visitor.nodes:
             graph.add_node(node)
@@ -2009,6 +2036,13 @@ def _canonicalize_phantoms(graph: KnowledgeGraph) -> int:
                 # Bare-name phantom — the phantom has no module path, so
                 # fall back to "unique leaf match across the whole graph".
                 matched = list(all_candidates)
+
+        # A test helper must not absorb a name that production code
+        # references — see ``test_node_is_off_limits``.
+        matched = [
+            pair for pair in matched
+            if not test_node_is_off_limits(g, pair[0], nid)
+        ]
 
         if not matched:
             continue

--- a/sphinxcontrib/nexus/merge.py
+++ b/sphinxcontrib/nexus/merge.py
@@ -9,6 +9,7 @@ from sphinxcontrib.nexus._mappings import (
     TYPE_RANK,
     candidate_rank,
     candidates_are_ambiguous,
+    test_node_is_off_limits,
 )
 from sphinxcontrib.nexus.graph import EdgeType, KnowledgeGraph, NodeType
 
@@ -45,7 +46,14 @@ def merge_graphs(
     for node_id, ast_attrs in ag.nodes(data=True):
         if node_id in sg:
             # Enrich existing Sphinx node with AST metadata.
-            for key in ("file_path", "lineno", "end_lineno"):
+            # ``in_test_file`` / ``is_test`` are facts about the FILE a
+            # symbol was defined in, which only the AST side can know —
+            # the Sphinx side has no opinion on them. Without copying
+            # them, any test symbol that is also autodoc'd loses the
+            # flag, and the rule that stops test helpers absorbing
+            # production references silently stops applying to it.
+            for key in ("file_path", "lineno", "end_lineno",
+                        "in_test_file", "is_test"):
                 if key in ast_attrs:
                     sg.nodes[node_id][key] = ast_attrs[key]
             sg.nodes[node_id]["source"] = "both"
@@ -121,8 +129,14 @@ def reconcile_unresolved(graph: KnowledgeGraph) -> int:
         by_name.setdefault(name.rsplit(".", 1)[-1], []).append((node_id, name))
         by_name.setdefault(name, []).append((node_id, name))
 
-    def _best_match(name: str) -> str | None:
+    def _best_match(name: str, phantom_id: str) -> str | None:
         candidates = by_name.get(name)
+        if not candidates:
+            return None
+        candidates = [
+            (cid, cname) for cid, cname in candidates
+            if not test_node_is_off_limits(g, cid, phantom_id)
+        ]
         if not candidates:
             return None
         ranked = sorted(
@@ -137,7 +151,7 @@ def reconcile_unresolved(graph: KnowledgeGraph) -> int:
     for node_id, attrs in list(g.nodes(data=True)):
         if attrs.get("type") != NodeType.UNRESOLVED.value:
             continue
-        concrete_id = _best_match(attrs.get("name", ""))
+        concrete_id = _best_match(attrs.get("name", ""), node_id)
         if not concrete_id or concrete_id == node_id or concrete_id not in g:
             continue
         for src, _, key, data in list(g.in_edges(node_id, keys=True, data=True)):

--- a/tests/test_dead_references.py
+++ b/tests/test_dead_references.py
@@ -1320,3 +1320,102 @@ def test_prose_references_do_not_count_as_minting():
     entry = next(d for d in GraphQuery(kg).dead_references().dead
                  if d.target_name == "proj.retired.compute")
     assert entry.minted_by == ["/proj/scratch/probe.py"]
+
+
+# ---------------------------------------------------------------------------
+# The test tree must not absorb production references
+# ---------------------------------------------------------------------------
+#
+# Bare-name fuzzy matching is deliberately more permissive than Sphinx —
+# it recovers thousands of real doc-page-to-class links that Sphinx
+# renders as plain text. The test tree is where that generosity goes
+# wrong: test modules are full of short generic names, so they act as a
+# magnet for any bare name with no better candidate. Measured on
+# ORPHEUS: 578 bare references from production code landed on test
+# helpers, including a reactor-physics operator's `:attr:`K`` binding to
+# a test class's attribute.
+
+
+def _test_magnet_graph(referrer_is_test: bool = False) -> KnowledgeGraph:
+    kg = KnowledgeGraph()
+    _node(kg, "py:module:proj.solver", NodeType.MODULE, "proj.solver",
+          file_path="/proj/solver.py", **({"in_test_file": True} if referrer_is_test else {}))
+    # The only same-leaf candidate lives in the test tree.
+    _node(kg, "py:attribute:tests.test_rate.Case.K", NodeType.ATTRIBUTE,
+          "tests.test_rate.Case.K", file_path="/tests/test_rate.py",
+          in_test_file=True)
+    _node(kg, "py:attribute:K", NodeType.UNRESOLVED, "K")
+    kg.add_edge(GraphEdge(source="py:module:proj.solver", target="py:attribute:K",
+                          type=EdgeType.REFERENCES, metadata={"reftarget": "K"}))
+    return kg
+
+
+def test_production_reference_does_not_bind_to_a_test_helper():
+    from sphinxcontrib.nexus.ast_analyzer import _canonicalize_phantoms
+
+    kg = _test_magnet_graph()
+    _canonicalize_phantoms(kg)
+    targets = {t for _, t, d in kg.nxgraph.out_edges("py:module:proj.solver", data=True)
+               if d.get("type") == EdgeType.REFERENCES.value}
+    assert "py:attribute:tests.test_rate.Case.K" not in targets, (
+        "a production docstring's bare name bound to a test helper"
+    )
+    assert "py:attribute:K" in targets
+
+
+def test_test_to_test_bare_reference_still_binds():
+    """The direction is the discriminator, not the name.
+
+    A test module referencing a test helper is legitimate and must keep
+    working — otherwise this rule would just be a blanket ban.
+    """
+    from sphinxcontrib.nexus.ast_analyzer import _canonicalize_phantoms
+
+    kg = _test_magnet_graph(referrer_is_test=True)
+    _canonicalize_phantoms(kg)
+    targets = {t for _, t, d in kg.nxgraph.out_edges("py:module:proj.solver", data=True)
+               if d.get("type") == EdgeType.REFERENCES.value}
+    assert "py:attribute:tests.test_rate.Case.K" in targets
+
+
+def test_non_test_candidate_is_unaffected():
+    """Production-to-production bare matching keeps its generosity."""
+    from sphinxcontrib.nexus.ast_analyzer import _canonicalize_phantoms
+
+    kg = KnowledgeGraph()
+    _node(kg, "py:module:proj.docs", NodeType.MODULE, "proj.docs",
+          file_path="/proj/docs.py")
+    _node(kg, "py:class:proj.cp.solver.CPMesh", NodeType.CLASS,
+          "proj.cp.solver.CPMesh", file_path="/proj/cp/solver.py")
+    _node(kg, "py:class:CPMesh", NodeType.UNRESOLVED, "CPMesh")
+    kg.add_edge(GraphEdge(source="py:module:proj.docs", target="py:class:CPMesh",
+                          type=EdgeType.REFERENCES, metadata={"reftarget": "CPMesh"}))
+    _canonicalize_phantoms(kg)
+    targets = {t for _, t, d in kg.nxgraph.out_edges("py:module:proj.docs", data=True)
+               if d.get("type") == EdgeType.REFERENCES.value}
+    assert "py:class:proj.cp.solver.CPMesh" in targets
+
+
+def test_test_helpers_inside_the_test_root_are_flagged(tmp_path):
+    """``is_test`` must cover helper modules, not just ``test_*.py``.
+
+    Test patterns are written project-relative (``tests/*``) but paths
+    were matched relative to the SOURCE DIR — and when that dir is
+    itself the test root, the prefix is gone and only the filename
+    patterns fire. 2113 of ORPHEUS's test-tree nodes carried no
+    ``is_test``, and they were exactly the ones catching bad bindings.
+    """
+    from sphinxcontrib.nexus.ast_analyzer import analyze_directory
+
+    (tmp_path / "tests" / "_harness").mkdir(parents=True)
+    (tmp_path / "tests" / "__init__.py").write_text("")
+    (tmp_path / "tests" / "_harness" / "__init__.py").write_text("")
+    (tmp_path / "tests" / "_harness" / "registry.py").write_text(
+        "def record():\n    pass\n"
+    )
+    # Analyzed as its own source dir, the way nexus_extra_source_dirs does.
+    g = analyze_directory(
+        source_dir=tmp_path / "tests", project_root=tmp_path, exclude_patterns=[],
+    ).nxgraph
+    node = next(n for n in g if str(n).endswith("registry.record"))
+    assert g.nodes[node].get("in_test_file") is True


### PR DESCRIPTION
Fixes the test-tree binding flagged during #47's validation. Spun out #49 for the adjacent `_infer_implements` defect rather than bundling it.

## What was wrong

Bare-name fuzzy matching is **deliberately** more permissive than Sphinx: an api page writing ``:class:`CPMesh``` with no `currentmodule` fails Sphinx's own searchmode-0 lookup and renders as plain text, while nexus resolves it. That generosity recovers thousands of real doc-page-to-class links and is worth keeping — so this is not a rollback of it.

The test tree is where it went wrong. Test modules are full of short generic names, so they act as a magnet for any bare name with no better candidate:

| authored | bound to |
|---|---|
| ``:attr:`K``` in `RadialCharacteristicEmission` | `tests…TestNegativeControlPartialConsistency.K` |
| `record` in `IterationHistory` | `tests._harness.registry.record` |
| `omega_dot_n` in `AngularTraceSpace` | a test snapshot generator |

Production code does not reference test helpers, so the **direction** is the discriminator, not the name. Test-to-test bare references are untouched, and explicit fully-qualified references never create a phantom, so they are unaffected — 138 still resolve on ORPHEUS.

## Two things had to be fixed underneath

**`is_test` was never set on 2113 test-tree nodes.** Test patterns are written project-relative (`tests/*`) but were matched against the path relative to the *source dir* — and when that dir is itself the test root (`nexus_extra_source_dirs = ['tests']`) the prefix is gone, so only the `test_*.py` filename patterns fired. Helper modules were invisible, and they were exactly the ones catching bad bindings.

**`is_test` is the wrong question anyway.** On a function it means "this IS a test case" — name-based, and `retest` / `dead_functions` depend on that meaning, so a helper like `_harness.registry.record` legitimately lacks it. Added `in_test_file` for the different question. `merge_graphs` now propagates both; without that, any autodoc'd test symbol silently lost the flag and the rule stopped applying to it.

## Results — ORPHEUS

Production→test bare bindings: **0**. All named offenders gone.

**Dead references 0 → 1, and the 1 is true:**

```
orpheus/sn/solver.py:2354   :mod:`tests.sn.test_scattering_operator`
actual module               tests.sn.operators.test_scattering_operator
```

The test moved under `operators/` and the docstring was never updated. Leaf-matching had been folding the stale path onto the real module and hiding it. The count going *up* is the point.

## The edge delta, chased rather than accepted

Edges fell 2486. An A/B rebuild (rule off: 211,209 / rule on: 208,630) isolated it entirely to `implements`: 16,459 → 13,932.

Cause: `_infer_implements` counts any target typed `function`/`method`/`class`, so bare names folded onto test symbols were feeding it inferences like `TestSlabViaUnifiedDiscrepancyDiagnostic implements peierls-slab-polar`. A test *verifies* an equation; it does not implement one.

~195 such edges survive from explicitly-qualified references and cannot be removed by any resolution change — `_infer_implements` has to decline them itself. **Filed as #49**, not bundled, because it moves `verification_coverage` numbers.

## Tests

4 new. Both fixes verified against unfixed code, reverted **individually**:

```
revert off-limits rule    → test_production_reference_does_not_bind_to_a_test_helper  FAILED
revert in_test_file stamp → test_test_helpers_inside_the_test_root_are_flagged        FAILED
```

677 pass, pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
