### PR TITLE
fix(merge): a test verifies an equation, it does not implement one (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,22 @@ Tested against a real `sphinx-proof` build (`tests/roots/test-proof-relations`)
 rather than a fixture guess, since the whole point is what the upstream
 extension actually publishes. `sphinx-proof` is now a test-only dependency.
 
+### Fixed — a test verifies an equation, it does not implement one (#49)
+
+`_infer_implements` pairs a doc page's equations with the code symbols it
+documents, on shared name tokens, and nothing excluded test code. Test classes
+were unusually prone to it: `TestSlabViaUnifiedDiscrepancyDiagnostic` shares
+`slab` / `peierls` / `multigroup` with half the equations on its page.
+
+IMPLEMENTS means "this code is the equation"; a test verifies one, which the
+graph already models with TESTS edges. Now excludes nodes flagged
+`in_test_file` — a recorded fact about the defining file, not a name heuristic.
+
+On ORPHEUS this removes 194 edges. `verification_coverage` reports the same
+implemented and verified counts before and after, so no equation was drawing its
+status from a test-implements edge — the false ALIVE was latent rather than
+active on that corpus.
+
 ### Fixed — test helpers no longer absorb production references
 
 Bare-name fuzzy matching is deliberately more permissive than Sphinx: an api

--- a/sphinxcontrib/nexus/merge.py
+++ b/sphinxcontrib/nexus/merge.py
@@ -227,7 +227,26 @@ def _infer_implements(g: "nx.MultiDiGraph") -> None:
 
             if tgt_type == "equation" and tgt not in eq_map:
                 eq_map[tgt] = _tokenize(tgt_name)
-            elif tgt_type in code_types and edge_type == "documents" and tgt not in code_map:
+            elif (
+                tgt_type in code_types
+                and edge_type == "documents"
+                and tgt not in code_map
+                # A test does not IMPLEMENT an equation — it VERIFIES
+                # one, which the graph already models with TESTS edges
+                # (``@pytest.mark.verifies``, the ``verifies``
+                # directive). Inferring IMPLEMENTS onto a test inverts
+                # the relationship the V&V surface reads: an equation
+                # whose only implementer is a test class reads as
+                # implemented when nothing implements it, and that is a
+                # false ALIVE — the direction that stays silent.
+                #
+                # Test classes are unusually prone to it because the
+                # match is on shared name tokens:
+                # ``TestSlabViaUnifiedDiscrepancyDiagnostic`` shares
+                # ``slab`` / ``peierls`` / ``multigroup`` with half the
+                # equations on its page and collects a dozen edges.
+                and not tgt_attrs.get("in_test_file")
+            ):
                 code_map[tgt] = _tokenize(tgt_name)
 
         equations = list(eq_map.items())

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -549,3 +549,114 @@ def test_merge_graphs_no_longer_reconciles_on_its_own():
     """The phase boundary is the point — pin it."""
     merged = merge_graphs(*_ambiguous_pair())
     assert "py:module:derivations" in merged.nxgraph
+
+
+# ---------------------------------------------------------------------------
+# IMPLEMENTS is not what a test does to an equation (#49)
+# ---------------------------------------------------------------------------
+#
+# `_infer_implements` pairs a doc page's equations with the code symbols
+# it documents, on shared name tokens. Nothing excluded test code, so a
+# test class reaching a theory page became an implementation candidate —
+# and test classes are unusually prone to it, since
+# `TestSlabViaUnifiedDiscrepancyDiagnostic` shares `slab`/`peierls`/
+# `multigroup` with half the equations on its page.
+#
+# Measured on ORPHEUS: 2722 such edges, 195 of them surviving purely
+# from correctly-qualified references that no resolution change can
+# remove.
+
+
+def _implements_fixture(mark_test: bool = True) -> KnowledgeGraph:
+    kg = KnowledgeGraph()
+    kg.add_node(GraphNode(id="doc:theory/slab", type=NodeType.FILE,
+                          name="theory/slab", display_name="slab",
+                          domain="std", docname="theory/slab"))
+    kg.add_node(GraphNode(id="math:equation:peierls-slab-polar",
+                          type=NodeType.EQUATION, name="peierls-slab-polar",
+                          display_name="peierls-slab-polar", domain="math"))
+    kg.add_edge(GraphEdge(source="doc:theory/slab",
+                          target="math:equation:peierls-slab-polar",
+                          type=EdgeType.CONTAINS))
+
+    test_meta = {"file_path": "/tests/test_slab.py"}
+    if mark_test:
+        test_meta["in_test_file"] = True
+    kg.add_node(GraphNode(
+        id="py:class:tests.test_slab.TestSlabPolar", type=NodeType.CLASS,
+        name="tests.test_slab.TestSlabPolar", display_name="TestSlabPolar",
+        domain="py", metadata=test_meta,
+    ))
+    kg.add_edge(GraphEdge(source="doc:theory/slab",
+                          target="py:class:tests.test_slab.TestSlabPolar",
+                          type=EdgeType.DOCUMENTS))
+
+    # A real implementation on the same page, sharing the same token.
+    kg.add_node(GraphNode(
+        id="py:function:proj.slab.solve_slab_polar", type=NodeType.FUNCTION,
+        name="proj.slab.solve_slab_polar", display_name="solve_slab_polar",
+        domain="py", metadata={"file_path": "/proj/slab.py"},
+    ))
+    kg.add_edge(GraphEdge(source="doc:theory/slab",
+                          target="py:function:proj.slab.solve_slab_polar",
+                          type=EdgeType.DOCUMENTS))
+    return kg
+
+
+def _implements_targets(g, source):
+    return {
+        t for _, t, d in g.out_edges(source, data=True)
+        if d.get("type") == EdgeType.IMPLEMENTS.value
+    }
+
+
+def test_test_class_does_not_implement_an_equation():
+    kg = _implements_fixture()
+    _infer_implements(kg.nxgraph)
+    assert not _implements_targets(
+        kg.nxgraph, "py:class:tests.test_slab.TestSlabPolar",
+    ), "a test class was inferred to IMPLEMENT an equation"
+
+
+def test_real_implementation_on_the_same_page_still_infers():
+    """Excluding tests must not disable the inference itself."""
+    kg = _implements_fixture()
+    _infer_implements(kg.nxgraph)
+    assert "math:equation:peierls-slab-polar" in _implements_targets(
+        kg.nxgraph, "py:function:proj.slab.solve_slab_polar",
+    )
+
+
+def test_the_equation_is_not_left_looking_implemented_by_a_test():
+    """The consequence that makes this a false ALIVE.
+
+    An equation whose only IMPLEMENTS edge points at a test class reads
+    as implemented when nothing implements it — and unlike a false DEAD,
+    nothing announces it.
+    """
+    kg = _implements_fixture()
+    # Drop the real implementation: the test class is the only candidate.
+    kg.nxgraph.remove_node("py:function:proj.slab.solve_slab_polar")
+    _infer_implements(kg.nxgraph)
+
+    implementers = {
+        s for s, _, d in kg.nxgraph.in_edges("math:equation:peierls-slab-polar",
+                                             data=True)
+        if d.get("type") == EdgeType.IMPLEMENTS.value
+    }
+    assert not implementers, (
+        "the equation reports an implementer that is only a test"
+    )
+
+
+def test_unmarked_test_node_is_still_inferred():
+    """The exclusion keys on `in_test_file`, nothing heuristic.
+
+    Pinned so the rule cannot quietly start guessing from names — a
+    production class called `TestHarness` is not test code.
+    """
+    kg = _implements_fixture(mark_test=False)
+    _infer_implements(kg.nxgraph)
+    assert _implements_targets(
+        kg.nxgraph, "py:class:tests.test_slab.TestSlabPolar",
+    )


### PR DESCRIPTION
Closes #49.

> **Stacked on #50** — it keys on the `in_test_file` flag that lands there. Merge #50 first; this branch was cut from it, so the diff shown here is only the `_infer_implements` change.

## The claim being removed

```
py:class:tests.derivations.test_peierls_multigroup.TestSlabViaUnifiedDiscrepancyDiagnostic
    -implements->  math:equation:peierls-slab-polar
    -implements->  math:equation:peierls-mg-operator
    ...
```

`_infer_implements` pairs a doc page's equations with the code symbols it documents, on shared name tokens. Nothing excluded test code, and test classes are unusually prone to it — that class name shares `slab` / `peierls` / `multigroup` with half the equations on its page and collected a dozen edges.

IMPLEMENTS means "this code **is** the equation". A test **verifies** one, which the graph already models with TESTS edges (`@pytest.mark.verifies`, the `verifies` directive). Pointing IMPLEMENTS at a test inverts the relationship the V&V surface reads.

Keyed on `in_test_file` — a recorded fact about the defining file, not a name heuristic. A production class called `TestHarness` is not test code, and that is pinned by a test.

## Results, including the part that undercuts the issue

| | before | after |
|---|---|---|
| `implements` edges | 13,932 | 13,738 |
| touching test symbols | 194 | **0** |

**The coverage effect is smaller than #49 implied, and that is worth saying plainly.** `verification_coverage` reports `implemented=35` and `verified=683` **both before and after**. No ORPHEUS equation was drawing its status from a test-implements edge, so the false ALIVE was **latent, not active** on this corpus.

The mechanism is real — an equation whose only implementer is a test class would read as implemented, and nothing would announce it — but no equation is in that state today. `orphan_code` rises 9,020 → 9,027 as those test classes lose their only inferred edge.

I wrote #49 arguing this was actively corrupting the V&V surface. Measuring it says the surface was fine and the inference was wrong anyway. Both facts belong in the record.

## Tests

4 new. Verified against unfixed code — the two that depend on the exclusion fail without it:

```
test_test_class_does_not_implement_an_equation                 FAILED
test_the_equation_is_not_left_looking_implemented_by_a_test    FAILED
```

The other two are guards that must pass either way: a real implementation on the same page still infers, and an unmarked node is still eligible.

681 pass, pyright clean. ORPHEUS dead references remain at 1 — the true one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
