### PR TITLE
docs: a Sphinx guide, built by the extension it documents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,55 @@ jobs:
       - name: Run tests
         run: python -m pytest tests/ -v
 
+  docs:
+    # The documentation enables the extension, so building it runs the
+    # whole pipeline — Sphinx extraction, AST analysis, merge, export —
+    # against a real project. A unit-test suite cannot catch a build that
+    # only breaks with a real BuildEnvironment; this does.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install with docs extra
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[docs]"
+
+      # -W turns Sphinx warnings into errors: a broken cross-reference in
+      # the guide is exactly the drift nexus exists to catch, so its own
+      # docs should not ship one.
+      - name: Build docs
+        run: python -m sphinx -b html docs docs/_build/html -E -W
+
+      - name: The graph nexus built of itself must be non-trivial
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from sphinxcontrib.nexus.export import load_sqlite
+
+          db = Path("docs/_build/html/_nexus/graph.db")
+          assert db.exists(), "no graph written by the docs build"
+          g = load_sqlite(db).nxgraph
+          # Guards the shape, not a magic number: a build that silently
+          # extracted nothing would still write a valid empty database.
+          assert g.number_of_nodes() > 500, g.number_of_nodes()
+          assert g.number_of_edges() > 1000, g.number_of_edges()
+          types = {a.get("type") for _, a in g.nodes(data=True)}
+          for expected in ("module", "class", "function", "file"):
+              assert expected in types, f"no {expected} nodes in self-graph"
+          print(f"self-graph: {g.number_of_nodes()} nodes, "
+                f"{g.number_of_edges()} edges")
+          PY
+
+      - name: Nexus must not report drift in its own documentation
+        run: |
+          python -m sphinxcontrib.nexus.cli dead-references \
+            --db docs/_build/html/_nexus/graph.db --exit-code
+
   pyright:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 _nexus/
 *.db
 .claude/
+# Sphinx output for nexus's own docs (includes the self-graph).
+docs/_build/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ A unified code + documentation knowledge graph extracted from Sphinx builds and 
 
 **What makes it unique:** Nexus is the only tool that puts code structure (call graphs, imports, inheritance, type annotations) and documentation structure (equations, cross-references, citations, theory pages) in the same graph. This enables queries that are impossible with code-only or doc-only tools — like tracing from a literature citation through an equation to the function that implements it.
 
+**Documentation:** `docs/` builds a full guide with Sphinx — [authoring](docs/guide/authoring.md) (what you write, what you get), [vocabulary](docs/guide/vocabulary.md) (node and edge types, id format), [tools](docs/guide/tools.md) (the 40 MCP tools by the question they answer), and [CLI](docs/guide/cli.md). The docs enable the extension, so building them is also an end-to-end exercise of nexus against a real project — its own.
+
+```bash
+pip install -e ".[docs]"
+python -m sphinx -b html docs docs/_build/html
+```
+
 ## Quick Start
 
 ```bash
@@ -92,6 +99,47 @@ Nexus works with any Python project:
 - **Flat modules**: directories with `.py` files but no `__init__.py` — detected automatically
 - **Custom sys.path**: projects that add directories to `sys.path` in `conf.py` — picked up from the Sphinx build environment
 
+## How References Resolve
+
+A reference in prose becomes an edge only if nexus can decide what it names.
+The rules matter because a *wrong* binding is invisible — it produces a
+well-formed edge pointing at a node that exists, which nothing downstream can
+question — while a missing one shows up in `dead_references`.
+
+**Namespace first.** A relative reference (`` :meth:`Quadrature.product` ``,
+`` :class:`SNMesh` ``) resolves against the namespace of the node it is
+written in, following Sphinx's `PythonDomain.find_obj`: `modname.classname.target`,
+then `modname.target`, then `target` as a fully qualified key. The same bare
+name in two classes resolves to two different methods, so resolution is
+per-reference rather than once per name.
+
+**Then ranked matching.** When namespace context does not decide it, candidates
+are ranked: a real definition always beats a placeholder, then the role's own
+type preference, then concreteness, then a file-backed node, then the shortest
+qualified name. Passes that rewire the graph decline when the top candidates
+are indistinguishable in kind; passes that must return something take the
+minimum.
+
+**Deliberately more generous than Sphinx.** An api page writing
+`` :class:`CPMesh` `` with no `currentmodule` fails Sphinx's own lookup and
+renders as plain text — nexus resolves it. That recovers thousands of real
+doc-page-to-class links.
+
+**Except into the test tree.** Test modules are full of short generic names
+(`K`, `record`, `slab`), so they act as a magnet for any bare name with no
+better candidate. A test-tree candidate is refused for a reference from
+production code; test-to-test references and fully-qualified references are
+unaffected.
+
+**Scanned directories define the namespace.** Any directory you analyze
+contributes names that bare references can bind to. A prototyping directory
+importing a module retired months ago mints placeholders that roles elsewhere
+then match — exclude it:
+
+```python
+nexus_source_exclude_patterns = ["scratch/*"]
+```
+
 ## What the Graph Contains
 
 ### Node Types (16)
@@ -106,9 +154,9 @@ Nexus works with any Python project:
 | `function` | Sphinx + AST | Python functions |
 | `class` | Sphinx + AST | Python classes |
 | `method` | Sphinx + AST | Python methods |
-| `attribute` | Sphinx + AST | Class attributes |
+| `attribute` | Sphinx + AST | Class and instance attributes — including `self.x: T` in `__init__`, `#:`-documented bindings, and `Cls.attr = ...` bound after the class body |
 | `module` | Sphinx + AST | Python modules |
-| `data` | Sphinx | Module-level data |
+| `data` | Sphinx + AST | Module-level constants |
 | `exception` | Sphinx | Exception classes |
 | `type` | Sphinx | Type aliases |
 | `external` | Auto-detected | stdlib, builtins, installed packages (numpy, scipy, ...) |
@@ -178,7 +226,7 @@ The static graph is *what can run*; a runtime overlay is *what actually ran*. Ca
 - **`verification_audit`** — complete V&V audit: coverage + staleness + prioritized gap list (supports `group_by` and `include_tests`)
 - **`verification_gaps`** — untagged tests, unverified equations, missing err catchers (supports `module` and `level` filters)
 - **`staleness`** — detect docs that drifted from code: git-timestamp drift plus a dead-reference summary
-- **`dead_references`** — doc/docstring references whose code target no longer exists (deleted/renamed symbols still referenced by theory pages, docstrings, or quoted type annotations — Sphinx renders these as plain text with no warning); project-rooted names only, with re-export and inheritance rescue passes to keep false positives out
+- **`dead_references`** — doc/docstring references whose code target no longer exists (deleted/renamed symbols still referenced by theory pages, docstrings, or quoted type annotations — Sphinx renders these as plain text with no warning); project-rooted names only, with re-export and inheritance rescue passes to keep false positives out. Findings carry `minted_by`: the files whose own code created the placeholder the reference bound to, so an unmaintained directory minting a namespace is named directly rather than showing up as N unrelated dead references
 - **`session_briefing`** — AI agent context restoration
 - **`trace_error`** — trace from failing test to equations on call path
 - **`migration_plan`** — plan dependency migration with phased blast radius

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,51 @@
+"""Sphinx configuration for the sphinxcontrib-nexus documentation.
+
+The extension documents itself: ``sphinxcontrib.nexus`` is enabled
+below, so every build writes a knowledge graph of this project into
+``_build/html/_nexus/graph.db``. That is deliberate — it dogfoods the
+extension against a real codebase on every docs build, and the graph is
+available to query while working on nexus itself.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sphinxcontrib.nexus import __version__  # noqa: E402
+
+project = "sphinxcontrib-nexus"
+author = "Rodrigo de Oliveira"
+release = __version__
+version = __version__
+
+extensions = [
+    "myst_parser",
+    "sphinx.ext.autodoc",
+    # The codebase writes Google-style docstrings (``Args:`` blocks).
+    # Without napoleon, docutils reads those as an unexpected indent.
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
+    "sphinxcontrib.nexus",
+]
+
+myst_enable_extensions = ["colon_fence", "deflist"]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "notes/*"]
+
+html_theme = "alabaster"
+html_static_path = []
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master", None),
+}
+
+# -- Nexus ----------------------------------------------------------------
+# `notes/` holds design spikes, not shipped source. Nothing else to
+# exclude: the package IS the thing being documented.
+nexus_source_exclude_patterns = []

--- a/docs/guide/authoring.md
+++ b/docs/guide/authoring.md
@@ -1,0 +1,230 @@
+# Authoring: what you write, what you get
+
+This page is for whoever writes the docstrings, `.rst` pages, and tests.
+Every construct below is something you already write for Sphinx — the point
+is what each one *becomes* in the graph, so you can tell which prose is
+load-bearing and which is decoration.
+
+Nothing here is required. Nexus extracts a useful graph from an
+uninstrumented project; the directives buy precision where inference
+guesses.
+
+## The short version
+
+| You write | You get |
+|---|---|
+| `` :func:`pkg.mod.solve` `` in a docstring | `documents` edge → that function |
+| `` :eq:`transport-balance` `` | `equation_ref` edge → the equation |
+| `.. math:: :label: foo` | an `equation` node, referenceable anywhere |
+| `@pytest.mark.verifies("foo")` | `tests` edge, test → equation |
+| `.. verifies:: foo` | the same edge, declared from the doc side |
+| `.. implements:: foo` | `implements` edge, code → equation |
+| `.. discretizes:: foo` | `discretizes` edge between two statements |
+| `#: prose with :class:`X`` above an attribute | edges from that attribute |
+| `Cls.attr = ...` after the class body | an `attribute` node |
+
+## Referencing code from prose
+
+Standard Sphinx roles in a docstring or `.rst` page become edges. No
+configuration:
+
+```python
+def solve_sn(mesh, quad):
+    """Solve the S_N transport equation.
+
+    Uses :class:`pkg.sn.mesh.SNMesh` and the quadrature from
+    :func:`pkg.quadrature.gauss_legendre`. Implements
+    :eq:`transport-balance`.
+    """
+```
+
+That docstring produces three edges: two `documents` (to the class and the
+function) and one `equation_ref` (to the equation label).
+
+### Relative references resolve like Sphinx does
+
+You do not have to fully qualify. A reference resolves against the
+namespace of the thing it is written in, following
+`PythonDomain.find_obj`:
+
+1. `modname.classname.target`
+2. `modname.target`
+3. `target` — as a **fully qualified key**
+
+Step 3 is the one that surprises people. The registry is keyed by full
+dotted names, so a bare `` :func:`solve` `` does **not** resolve just
+because its module is `automodule`-d — it resolves only if a *top-level*
+`solve` exists. This is why adding autodoc coverage does not fix bare
+references.
+
+Inside a class, `` :meth:`apply` `` finds that class's own `apply`. In a
+different class it finds a different one. The same spelling in two places
+is two different edges, which is why the graph resolves them per-reference
+rather than once per name.
+
+### What will not resolve
+
+A name that is neither in the referring namespace nor a top-level symbol
+stays unresolved and is reported by {ref}`dead-references`. That is
+faithful — Sphinx renders those as plain text with no warning, so the
+graph is showing you a link your readers are not getting.
+
+## Defining equations
+
+A labelled math block becomes a node other things can point at:
+
+```rst
+.. math::
+   :label: transport-balance
+
+   \Omega \cdot \nabla \psi + \Sigma_t \psi = q
+```
+
+Labels defined in **docstrings** work too. Nexus parses docstring math
+blocks even when Sphinx never renders that docstring, so a label defined
+in un-rendered prose is still a real node rather than a dangling
+reference.
+
+Reference it with `` :eq:`transport-balance` `` or
+`` :math:numref:`transport-balance` `` — both bind to the same node.
+
+## Relating statements to each other
+
+Equations are not a flat list. Three directives declare the spine, and
+each names its target as the argument:
+
+```rst
+.. math::
+   :label: sn-dd-closure
+
+   \psi_c = \tfrac{1}{2}(\psi_L + \psi_R)
+
+.. discretizes:: sn-transport-continuous
+```
+
+- `discretizes` — a discrete form → the continuous one it discretizes
+- `derives-from` — a specialization → the parent it was reduced from
+- `approximates` — a closure or truncation → the exact form it stands in for
+
+Direction is always **specific → general**. The source is the nearest
+preceding labelled statement, or an explicit `:label:` when you need to
+declare out of order:
+
+```rst
+.. approximates:: transport-continuous
+   :label: p1-closure
+```
+
+They work on [`sphinx-proof`](https://github.com/executablebooks/sphinx-proof)
+environments too — a `` .. prf:theorem:: `` with a `:label:` is a statement
+like any other, so a theorem can `derives-from` a definition.
+
+Misuse warns and is dropped rather than breaking the build: no bindable
+source, a statement related to itself, or a target that does not exist.
+
+## Declaring verification
+
+Two directions, same edge. From the test:
+
+```python
+@pytest.mark.verifies("transport-balance")
+def test_transport_balance_slab():
+    ...
+```
+
+Or from the doc side, when the test is somebody else's:
+
+```rst
+.. verifies:: transport-balance
+   :by: tests.sn.test_transport.test_balance_slab
+```
+
+And to say which code *is* an equation:
+
+```rst
+.. implements:: transport-balance
+   :by: pkg.sn.solver.solve_sn
+```
+
+An explicit `implements` always beats the inferred one. Nexus infers
+`implements` edges from shared name tokens between a page's equations and
+the code it documents, at `confidence=0.7`; a declared edge is `1.0` and
+suppresses inference for that pair.
+
+:::{note}
+A test **verifies** an equation — it does not implement one. Nexus never
+infers `implements` onto test code, because an equation whose only
+implementer is a test class would read as implemented when nothing
+implements it.
+:::
+
+## Documenting attributes
+
+Both forms are indexed, including the two that are easy to lose.
+
+**Attribute comments.** Sphinx's `#:` form documents the statement below
+it, and that prose is scanned for references:
+
+```python
+#: Spatial axis names, positional-by-axis — the crosswalk that
+#: :class:`FaceLayout` and :attr:`SNMesh.bc` both key on.
+AXIS_NAMES = ("x", "y", "z")
+```
+
+Comments are invisible to `ast`, so this is read from the token stream. A
+`#:` inside a string literal is not mistaken for one. The trailing form
+(`LIMIT = 10  #: capped by ...`) documents its own line.
+
+**Attributes bound after the class body.** The enum-like-singleton idiom
+is indexed:
+
+```python
+@dataclass(frozen=True)
+class BC:
+    kind: str
+
+BC.vacuum = BC("vacuum")      # type: ignore[attr-defined]
+BC.reflective = BC("reflective")
+```
+
+`BC.vacuum` is a real attribute at import time and autodoc documents it,
+so `` :data:`BC.vacuum` `` renders as a working link — it is now a node
+too. Only classes defined in the same module are extended;
+`os.environ = {}` does not forge an attribute onto a foreign symbol.
+
+`self.x: T` annotations in `__init__` are indexed as well, which matters
+because PEP 526 records them nowhere at runtime — an import-based checker
+cannot see them.
+
+(dead-references)=
+## Reading the drift report
+
+`nexus dead-references` reports doc and docstring references whose target
+does not exist. Sphinx renders these as plain text with no warning at any
+severity, which is what makes them silent.
+
+Each finding may carry **`minted_by`**: the source files whose own code
+(an import, call, annotation, or base class) created the placeholder the
+reference bound to. When those all sit in one unmaintained corner of the
+tree, that directory is the finding, not the reference:
+
+```
+  pkg.retired.compute  [python] — 1 site(s)
+      doc:theory/method  (theory/method.rst)
+      minted by code in:
+        /proj/scratch/probe.py
+```
+
+Prose does not count as minting. A page mentioning a vanished symbol is
+the reference being reported, not its cause.
+
+:::{warning}
+Any directory you scan contributes to the namespace that bare references
+resolve against. A prototyping directory importing a module retired months
+ago mints placeholder nodes that bare roles elsewhere can bind to. Exclude
+it:
+
+```python
+nexus_source_exclude_patterns = ["scratch/*", "student_resources/*"]
+```
+:::

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1,0 +1,108 @@
+# CLI
+
+Every command writes JSON to stdout unless noted, so they compose with
+`jq` and drop into shell hooks. The default database is
+`_nexus/graph.db` under the docs build directory; pass `--db` to point
+elsewhere.
+
+## Setup and serving
+
+```bash
+nexus setup                 # install skills for Claude Code / Cursor / Codex
+nexus serve --db <path>     # MCP server over stdio
+nexus analyze <src> --db <path>
+nexus status --db <path>    # node/edge counts by type
+```
+
+`nexus analyze` indexes Python source without Sphinx, for projects that
+have code but no docs build yet.
+
+## Asking questions
+
+```bash
+nexus query <text> --db <path>
+nexus context <node_id> --db <path>
+nexus neighbors <node_id> --db <path> [--direction in|out|both] [--edge-types calls,imports]
+nexus callers <node_id> --db <path> [--transitive] [--max-depth 3]
+nexus callees <node_id> --db <path> [--transitive] [--max-depth 3]
+nexus shortest-path <source> <target> --db <path> [--max-hops 8]
+nexus graph-query "<pattern>" --db <path> [--limit 50]
+```
+
+## Structure and smells
+
+```bash
+nexus god-nodes --db <path> [--top-n 10]
+nexus communities --db <path> [--min-size 3]
+nexus bridges --db <path> [--top-n 10]
+nexus processes --db <path> [--min-length 3]
+nexus native-place --db <path>
+nexus twin-paths --db <path>
+nexus discriminations --db <path>
+nexus dead-functions --db <path>
+nexus protocol-conformers --db <path>
+```
+
+## Documentation health
+
+```bash
+nexus dead-references --db <path> [--limit 50] [--format text|json]
+nexus staleness --db <path>
+nexus coverage --db <path>
+nexus audit --db <path> [--project-root .]
+nexus gaps --db <path>
+nexus provenance <node_id> --db <path>
+nexus briefing --db <path>
+```
+
+`dead-references` takes two flags built for CI:
+
+- `--quiet-when-clean` — print nothing when there are no findings, so a
+  hook stays silent until it has something to say
+- `--exit-code` — exit non-zero on findings, so it gates a pipeline
+
+## Change safety
+
+```bash
+nexus changes --db <path> [--scope all|staged|unstaged|branch]
+nexus retest --db <path> [--scope ...]
+nexus impact <node_id> --db <path>
+nexus rename <old> <new> --db <path> [--apply]
+nexus trace <test_node_id> --db <path>
+nexus migration <from> <to> --db <path>
+```
+
+`rename` is dry-run by default; `--apply` writes.
+
+## Runtime overlay
+
+```bash
+nexus runtime-ingest <artifact> --db <path> [--kind cprofile|coverage|viztracer] [--run NAME] [--source-prefix PFX]
+nexus runtime-runs --db <path>
+nexus runtime-hotspots --db <path> [--run NAME[,NAME...]] [--by cumtime|ncalls|tottime]
+nexus runtime-edges --db <path> [--mode dynamic_only|fired|dead] [--substantive-only]
+nexus runtime-branches --db <path> [--all]
+nexus runtime-timeline --db <path> [--max-depth N]
+```
+
+## Workspaces and the edit-time brief
+
+```bash
+nexus workspaces
+nexus file-brief <path> --db <path>
+```
+
+`file-brief` reads SQLite directly rather than loading the graph, which
+makes it fast enough for a `PostToolUse` hook — the ambient channel that
+pushes what the graph knows about a file *with* the edit, instead of
+waiting to be asked.
+
+## Visualising
+
+```bash
+nexus visualize --db <path>     # interactive force-directed HTML
+nexus ingest <file> --db <path> --llm-command <cmd>
+```
+
+A build also writes `_nexus/graph.html` automatically, and the
+`.. nexus-graph::` directive embeds it in a page.

--- a/docs/guide/python-api.md
+++ b/docs/guide/python-api.md
@@ -1,0 +1,102 @@
+# Python API
+
+Everything the MCP server and CLI do is available directly. Load a graph,
+wrap it in a query object, ask.
+
+```python
+from sphinxcontrib.nexus.export import load_sqlite
+from sphinxcontrib.nexus.query import GraphQuery
+
+kg = load_sqlite("docs/_build/html/_nexus/graph.db")
+q = GraphQuery(kg)
+
+q.query("ndarray", node_types=["external"])
+q.impact("py:function:pkg.sn.solver.solve_sn", direction="upstream")
+q.provenance_chain("py:function:pkg.sn.sweep.sweep_spherical")
+q.dead_references()
+```
+
+## The three objects worth knowing
+
+:::{note}
+The roles below are live cross-references into this project's own code, so
+they double as a check on the extension: if reference resolution regresses,
+nexus's own documentation build is where it shows up first.
+:::
+
+**The graph** — {class}`sphinxcontrib.nexus.graph.KnowledgeGraph` wraps a
+`networkx.MultiDiGraph` with the node and edge vocabulary from
+{doc}`vocabulary`. Node types are
+{class}`sphinxcontrib.nexus.graph.NodeType`, edge types
+{class}`sphinxcontrib.nexus.graph.EdgeType`.
+
+**The queries** — {class}`sphinxcontrib.nexus.query.GraphQuery` carries the
+whole read surface. Most MCP tools are a thin wrapper over one of its
+methods, so anything an agent can ask, you can ask in a REPL. A few tools
+compose several calls — `context` assembles {meth}`~sphinxcontrib.nexus.query.GraphQuery.get_node`
+and {meth}`~sphinxcontrib.nexus.query.GraphQuery.neighbors` rather than
+mapping to one method — so the tool list in {doc}`tools` is not a
+method-for-method index.
+
+**The checkout** — {class}`sphinxcontrib.nexus.workspace.Workspace` pairs a
+checkout with the graph built inside it. A graph is a snapshot of one
+checkout; this is what lets a session working in a git worktree find the
+right one.
+
+## Loading and saving
+
+{func}`sphinxcontrib.nexus.export.load_sqlite` and
+{func}`sphinxcontrib.nexus.export.write_sqlite` are the primary format —
+SQLite with FTS5 indexes, fast enough to load on every tool call.
+{func}`sphinxcontrib.nexus.export.read_sqlite_metadata` reads just the
+metadata table, which is how workspace discovery reports provenance for
+several checkouts without paying a full load.
+
+```python
+from sphinxcontrib.nexus.export import read_sqlite_metadata
+
+meta = read_sqlite_metadata("docs/_build/html/_nexus/graph.db")
+print(meta["provenance"]["git_commit"])
+```
+
+## Building a graph without Sphinx
+
+{func}`sphinxcontrib.nexus.ast_analyzer.analyze_directory` runs the AST
+half on its own, for projects with code but no docs build yet:
+
+```python
+from pathlib import Path
+from sphinxcontrib.nexus.ast_analyzer import analyze_directory
+
+kg = analyze_directory(
+    source_dir=Path("src"),
+    project_root=Path("."),
+    exclude_patterns=["scratch/*"],
+)
+```
+
+{func}`sphinxcontrib.nexus.merge.merge_graphs` folds an AST graph into a
+Sphinx one. Reconciliation is deliberately *not* part of it — call
+{func}`sphinxcontrib.nexus.merge.reconcile_unresolved` once after every
+merge, so it decides against the complete graph rather than one directory
+at a time.
+
+## Reference
+
+```{eval-rst}
+.. autoclass:: sphinxcontrib.nexus.graph.KnowledgeGraph
+   :members: add_node, add_edge, node_count, edge_count
+
+.. autoclass:: sphinxcontrib.nexus.query.GraphQuery
+   :members: query, get_node, neighbors, impact, provenance_chain,
+             dead_references, verification_coverage, staleness,
+             graph_query, retest
+
+.. autofunction:: sphinxcontrib.nexus.export.load_sqlite
+
+.. autofunction:: sphinxcontrib.nexus.export.read_sqlite_metadata
+
+.. autofunction:: sphinxcontrib.nexus.ast_analyzer.analyze_directory
+
+.. autofunction:: sphinxcontrib.nexus.merge.reconcile_unresolved
+```

--- a/docs/guide/tools.md
+++ b/docs/guide/tools.md
@@ -1,0 +1,156 @@
+# Tools: 40 MCP tools by the question they answer
+
+This page is for whoever drives the MCP server — an agent, or the person
+configuring one. Tools are grouped by the question, not by implementation,
+because picking the right one is the hard part.
+
+Every tool takes node ids in the form described in {doc}`vocabulary`.
+
+:::{tip}
+Start a session with `session_briefing`. It returns stale docs, V&V gaps,
+and recent changes in one call, which is usually enough to know which of
+the tools below you actually want.
+:::
+
+## Finding a starting point
+
+| Tool | Answers | Key args |
+|---|---|---|
+| `query` | Which symbols match this keyword? | `text`, `node_types`, `limit` |
+| `node_at` | Which node encloses this file position? Takes an LSP result or a stack-trace frame. Warns when the file changed since the graph was built | `file`, `line` |
+| `stats` | How big is this graph, and of what? | — |
+| `session_briefing` | What should I know before starting? | — |
+
+## Understanding one symbol
+
+| Tool | Answers | Key args |
+|---|---|---|
+| `context` | Everything about this node — attributes and all connections | `node_id` |
+| `neighbors` | What is directly connected? | `node_id`, `direction`, `edge_types` |
+| `callers` | What calls this? | `node_id`, `transitive`, `max_depth` |
+| `callees` | What does this call? | `node_id`, `transitive`, `max_depth` |
+| `shortest_path` | How do these two things connect at all? | `source`, `target`, `max_hops` |
+
+## Understanding the shape of the codebase
+
+| Tool | Answers | Key args |
+|---|---|---|
+| `communities` | What are the functional groupings? | `min_size` |
+| `bridges` | Which nodes hold communities together? | `top_n` |
+| `god_nodes` | What is most connected — and therefore riskiest? | `top_n` |
+| `processes` | What are the execution flows from entry points? | `min_length` |
+| `graph_query` | Anything else — a structured traversal | `pattern`, `limit` |
+
+`graph_query` takes a Cypher-flavoured pattern:
+
+```
+source_type -edge_type-> target_type [WHERE field=value]
+
+function -calls-> function
+file -contains-> equation
+* -implements-> equation
+function -type_uses-> external WHERE name=numpy*
+```
+
+`*` matches any type; `name=prefix*` does a prefix match.
+
+## Changing things safely
+
+| Tool | Answers | Key args |
+|---|---|---|
+| `impact` | What breaks if I change this? | `target`, `direction`, `max_depth`, `edge_types` |
+| `detect_changes` | What did my git diff actually touch, in graph terms? | `scope` |
+| `retest` | What is the minimum test set for these changes? | `scope` |
+| `rename` | Rename across files, safely | `old_name`, `new_name`, `dry_run` |
+| `migration_plan` | How do I get from this dependency to that one? | `from_dep`, `to_dep` |
+
+## Architecture smells (the missing-abstraction family)
+
+Each answers "is there a type or class that should exist here but doesn't?"
+
+| Tool | Answers | Key args |
+|---|---|---|
+| `native_place` | Which functions want to be methods? (Feature-Envy) | `min_callers`, `exclude`, `limit` |
+| `twin_paths` | Which computations are independently reimplemented? | `min_similarity`, `min_tokens`, `exclude`, `limit` |
+| `discriminations` | Which tags are branched on in many places? A tag discriminated at ten sites is usually a missing type | `min_sites`, `exclude`, `limit` |
+| `protocol_conformers` | Which classes satisfy a Protocol without declaring it? | `min_methods`, `exclude`, `limit` |
+| `dead_functions` | Which functions have no static callers? | `exclude`, `limit` |
+
+All take `exclude` for substring filtering, on top of the built-in
+`is_test` filter.
+
+## Runtime overlay — what actually ran
+
+The static graph is *what can run*; an overlay is *what did*. Capture is
+consumer-side: run a workload under a tracer, then `runtime_ingest` joins
+the artifact onto node ids and stores it in a sidecar
+(`_nexus/traces/<run>.json`) — never in `graph.db`, which is rewritten on
+every build.
+
+| Tool | Answers | Key args |
+|---|---|---|
+| `runtime_ingest` | Overlay a `cProfile` / `coverage --branch` / `viztracer` artifact | `artifact`, `kind`, `run`, `source_prefix` |
+| `runtime_runs` | Which runs have been ingested? | — |
+| `runtime_hotspots` | Where did time and iterations go? | `run`, `by`, `limit` |
+| `runtime_edges` | `dynamic_only` (dispatch the static graph missed), `fired`, `dead` | `run`, `mode`, `node`, `substantive_only` |
+| `runtime_branches` | Which branches never fired? Discriminators ranked first | `run`, `node`, `partial_only` |
+| `runtime_timeline` | In what order did things execute? | `run`, `max_depth`, `limit` |
+
+The query tools accept `run` as one name or a comma-separated list, so a
+canonical suite can be unioned.
+
+## Code + documentation fusion
+
+This is what the unified graph is *for* — none of these are answerable
+from code or docs alone.
+
+| Tool | Answers | Key args |
+|---|---|---|
+| `provenance_chain` | The citation → equation → code chain, plus the maths-to-maths spine in `relations` | `node_id` |
+| `verification_coverage` | Which equations have code and tests? | `status_filter` |
+| `verification_audit` | The complete V&V picture, one call | — |
+| `verification_gaps` | Untagged tests, unverified equations, missing error catchers | `module`, `level` |
+| `staleness` | Which docs drifted from their code? (git timestamps) | — |
+| `dead_references` | Which references name something that no longer exists? | `limit` |
+| `trace_error` | A failing test → the equations on its path | `test_node_id` |
+
+### On `dead_references`
+
+Sphinx renders a broken reference as plain text with no warning at any
+severity, so this is the only place that drift surfaces. Findings may
+carry `minted_by` — the files whose own code created the placeholder the
+reference bound to. See {ref}`dead-references` for how to read it.
+
+## Workspaces
+
+A graph is a snapshot of one checkout. A session working in a worktree
+must query *that* worktree's graph.
+
+| Tool | Answers | Key args |
+|---|---|---|
+| `workspaces` | Every checkout, which graph each carries, how fresh | — |
+| `use_workspace` | Switch the active graph | `ref` |
+
+## Ingestion
+
+| Tool | Answers | Key args |
+|---|---|---|
+| `ingest` | Add a paper or PDF to the graph | `file_path`, `llm_command` |
+
+## Resources (4)
+
+Read-only, no arguments:
+
+| Resource | Content |
+|---|---|
+| `nexus://graph/stats` | Node and edge counts by type, density |
+| `nexus://graph/communities` | Functional areas with top members |
+| `nexus://graph/schema` | Node types, edge types, id format |
+| `nexus://briefing` | Session briefing |
+
+## Failure behaviour
+
+Tools degrade rather than raise. Git missing, database corrupt, file
+vanished — you get an error payload and the previous snapshot is kept. A
+tool call never breaks the session, which means an empty result means
+"nothing found", not "something went wrong".

--- a/docs/guide/vocabulary.md
+++ b/docs/guide/vocabulary.md
@@ -1,0 +1,177 @@
+# Vocabulary: nodes, edges, and ids
+
+This page is the reference for reading a graph — what the node types mean,
+what each edge asserts, and how ids are built. If you are writing the docs
+that produce them, see {doc}`authoring`.
+
+## Node ids
+
+```
+<domain>:<type>:<qualified_name>
+```
+
+```
+py:function:pkg.sn.solver.solve_sn
+py:class:pkg.cp.solver.CPMesh
+py:method:pkg.cp.solver.CPMesh.compute_pinf_group
+py:module:pkg.sn.solver
+py:attribute:pkg.geometry.mesh.BC.vacuum
+py:tag:geometry
+math:equation:transport-balance
+prf:theorem:thm-balance
+doc:theory/discrete_ordinates
+std:label:theory-collision-probability
+citation:Bell1970
+```
+
+The id is stable across builds and is what every tool takes as input.
+Ids are derived, not stored twice: `prf:theorem:thm-balance` tells you the
+environment kind without a lookup.
+
+## Node types (16)
+
+**From documentation**
+
+| Type | What it is |
+|---|---|
+| `file` | A doc page |
+| `section` | A labelled section — a `:ref:` target |
+| `equation` | A labelled math block — an `:eq:` target |
+| `proof_object` | A labelled `sphinx-proof` environment. Kind in `metadata["prf_type"]`, prose in `metadata["statement"]` |
+| `term` | A glossary term |
+
+**From code**
+
+| Type | What it is |
+|---|---|
+| `module` | A Python module |
+| `class` | A class |
+| `function` | A module-level function |
+| `method` | A function bound to a class |
+| `attribute` | A class or instance attribute |
+| `data` | A module-level constant |
+| `exception` | An exception class |
+| `type` | A type alias |
+| `tag` | A string or enum value a function branches on — the target of `discriminates_on` |
+
+**Placeholders** — these are not definitions
+
+| Type | What it is |
+|---|---|
+| `external` | stdlib, builtins, or an installed package (`numpy`, `scipy`) |
+| `unresolved` | Referenced but never defined anywhere nexus scanned |
+
+:::{note}
+A placeholder exists so a reference has *something* to point at. It is
+never a definition, and resolution always prefers a real node over one —
+binding a live reference to a placeholder would manufacture a dead
+reference out of a symbol that exists.
+:::
+
+## Edge types (16)
+
+**Structure**
+
+| Edge | Asserts | Source |
+|---|---|---|
+| `contains` | Parent → child: toctree, module → function, class → method | Sphinx + AST |
+| `imports` | Module → module | AST |
+| `inherits` | Class → base class | AST |
+
+**Behaviour**
+
+| Edge | Asserts | Source |
+|---|---|---|
+| `calls` | Function → function it calls | AST |
+| `type_uses` | Function → a type in its annotations | AST |
+| `discriminates_on` | Function → a tag it branches on (`if x == "..."`, `match`) | AST |
+
+**Documentation**
+
+| Edge | Asserts | Source |
+|---|---|---|
+| `documents` | Doc page → the code symbol it documents | Sphinx |
+| `references` | A cross-reference (`:ref:`, `:term:`, and py-domain roles in docstrings) | Sphinx + AST |
+| `equation_ref` | Doc → equation (`:eq:`, `:math:numref:`) | Sphinx |
+| `cites` | Doc → citation | Sphinx |
+
+**Code ↔ maths**
+
+| Edge | Asserts | Source |
+|---|---|---|
+| `implements` | This code *is* this equation | Directive, or inferred at `confidence=0.7` |
+| `tests` | This test *verifies* this equation | `@pytest.mark.verifies`, `.. verifies::` |
+| `derives` | Paper-level lineage written by `ingest` | Ingest |
+
+**Statement relations** — always specific → general
+
+| Edge | Asserts | Source |
+|---|---|---|
+| `discretizes` | A discrete form → the continuous one it discretizes | Directive |
+| `derives_from` | A specialization → the parent it was reduced from | Directive |
+| `approximates` | A closure or truncation → the exact form it stands in for | Directive |
+
+## Reading edge metadata
+
+Two attributes carry most of the interpretive weight:
+
+**`confidence`** — `1.0` for anything extracted or declared, `0.7` for an
+inferred `implements`. Filter on it when a wrong edge would be expensive.
+
+**`source`** — `"ast"`, `"directive"`, `"inferred"`, or a registry name.
+An edge whose source is not `"inferred"` was asserted by a human.
+
+## How the pieces make a chain
+
+The reason these live in one graph rather than several:
+
+```
+citation:Bell1970
+    ←cites—  doc:theory/transport
+                 —contains→  math:equation:transport-balance
+                                 ←implements—  py:function:pkg.sn.solve_sn
+                                 ←tests—       py:function:tests.test_sn.test_balance
+                                 ←discretizes— math:equation:sn-dd-closure
+```
+
+`provenance_chain` walks exactly this, in both directions, from any entry
+point — a citation, an equation, or a function. The `relations` field
+returns the maths-to-maths spine separately, since "what does this
+discretize?" is a different question from "what implements it?".
+
+## Node metadata worth knowing
+
+| Key | Meaning |
+|---|---|
+| `file_path`, `lineno`, `end_lineno` | Definition site. Present ⇒ this came from real source |
+| `is_test` | This **is** a test case — name-based for functions |
+| `in_test_file` | This **lives in** the test tree — file-based |
+| `annotation` | The declared type of an attribute or data node |
+| `prf_type`, `statement` | `sphinx-proof` environment kind and its prose |
+| `decorators` | Rendered decorator list |
+
+:::{note}
+`is_test` and `in_test_file` are different questions. A helper in
+`tests/_harness/registry.py` lives in the test tree but is not a test
+case; `retest` and `dead_functions` depend on that distinction, and so
+does the rule that stops test helpers absorbing production references.
+:::
+
+## Provenance
+
+Every graph is a snapshot of **one checkout**. `metadata["provenance"]`
+records which:
+
+```json
+{
+  "source_root": "/Users/me/proj",
+  "built_at": "2026-08-10T11:09:46+00:00",
+  "git_branch": "main",
+  "git_commit": "52650a86",
+  "git_dirty": true
+}
+```
+
+If you work in git worktrees, this is what tells you whether the graph you
+are querying matches the code you are editing — see `workspaces` and
+`use_workspace` in {doc}`tools`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,42 @@
+# sphinxcontrib-nexus
+
+One queryable knowledge graph over **code structure** (call graphs, imports,
+inheritance, type annotations) and **documentation structure** (equations,
+cross-references, citations, theory pages).
+
+The premise: a docstring citing an equation, a test verifying it, and the
+function implementing it are three facts about the same thing. Kept in
+separate tools they drift silently. Kept in one graph they can be queried —
+and the drift becomes a finding.
+
+```{toctree}
+:maxdepth: 2
+:caption: Guide
+
+guide/authoring
+guide/vocabulary
+guide/tools
+guide/cli
+guide/python-api
+```
+
+## Which page do I want?
+
+| You are | Start at |
+|---|---|
+| Instrumenting a project — writing docstrings, `.rst`, directives | {doc}`guide/authoring` |
+| Reading a graph someone else built — node ids, edge meanings | {doc}`guide/vocabulary` |
+| Driving the MCP server from an agent | {doc}`guide/tools` |
+| At a terminal, or wiring a hook | {doc}`guide/cli` |
+| Working with the graph from Python | {doc}`guide/python-api` |
+
+## The graph of this project
+
+These docs are built with `sphinxcontrib.nexus` enabled, so building them
+writes a graph of nexus itself to `_build/html/_nexus/graph.db`. That is
+both a demonstration and a test: if the extension breaks on a real
+codebase, its own documentation build is the first thing to notice.
+
+```{nexus-graph}
+:height: 600px
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ nexus = "sphinxcontrib.nexus.cli:main"
 # extractor against a real build rather than a hand-built fixture.
 test = ["pytest", "sphinx-proof"]
 dev = ["ruff", "mypy"]
+# Building nexus's own documentation. The docs enable the extension, so a
+# docs build is also an end-to-end exercise of it against a real project.
+docs = ["myst-parser", "sphinx"]
 viz = []  # Sigma.js loaded from CDN, no Python deps needed
 
 [tool.flit.module]


### PR DESCRIPTION
There was no user-facing documentation beyond the README — no explanation of what the graph vocabulary means, which tool answers which question, or what a given directive produces.

## The guide

Split by audience, because authoring and querying are different jobs:

| Page | For |
|---|---|
| `guide/authoring` | Whoever writes docstrings, `.rst`, and tests — what you write, what you get |
| `guide/vocabulary` | Reading a graph someone else built — node/edge types, ids, metadata |
| `guide/tools` | The 40 MCP tools, grouped by the question they answer |
| `guide/cli` | Every command, with the CI-facing flags called out |
| `guide/python-api` | The three objects worth knowing, plus autodoc |

## The docs build is now a test

The docs enable `sphinxcontrib.nexus`, so building them runs the whole pipeline — Sphinx extraction, AST analysis, merge, export — against a real project: **3,061 nodes, 10,887 edges** of nexus analyzing itself.

A new CI job builds with `-W`, asserts the self-graph is non-trivial (a build that silently extracted nothing would still write a valid empty database), and gates on `dead-references --exit-code`. A unit-test suite cannot catch a failure that only appears with a real `BuildEnvironment`; this can.

## Two bugs found in the new material

**RST role syntax does not parse in MyST.** Every ``:class:`X`` I wrote rendered as literal text — visible in the HTML as `:class:<code>` rather than a link. MyST wants ``{class}`X``.

Worth recording beyond the fix: **nexus could not have caught this.** A role that fails to parse never becomes a reference, so `dead_references` has nothing to find. It catches references whose *target* vanished, not references the *parser* never recognised. Both render as plain text to a reader; only one is detectable. That limit is now written down rather than assumed away.

**`:no-index:` made the page unlinkable.** With it, autodoc does not register objects as xref targets, so every cross-reference to them silently failed to resolve. Removed — that page *is* their index.

Both were found by reading the rendered HTML, not by trusting a clean build.

## The gate was verified, not assumed

Injecting ``{class}`sphinxcontrib.nexus.graph.VanishedClass`` makes the gate report the target and exit 1. Before the two fixes above it reported nothing — not because the docs were clean, but because no reference had ever reached the graph.

## README

Links to the guide; documents `minted_by` on dead references; corrects the `attribute` and `data` rows for the forms now indexed (`self.x: T`, `#:` bindings, `Cls.attr = ...`); adds a **How References Resolve** section covering namespace-first resolution, candidate ranking, why nexus is deliberately more generous than Sphinx, and why scanned directories define the namespace.

Also enables `sphinx.ext.napoleon` — the codebase writes Google-style `Args:` blocks, which docutils otherwise reads as an unexpected indent.

681 tests pass, pyright clean, strict (`-W`) docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)