### PR TITLE
chore: release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,25 @@
 
 All notable changes to sphinxcontrib-nexus.
 
-## Unreleased
+## 0.17.0 — 2026-08-11
+
+### Added — documentation, built by the extension it documents (#52)
+
+A Sphinx guide under `docs/`, split by audience: **authoring** (what you write,
+what you get), **vocabulary** (node and edge types, id format, metadata),
+**tools** (the 40 MCP tools grouped by the question they answer), **cli**, and
+**python-api**.
+
+The docs enable `sphinxcontrib.nexus`, so building them runs the whole pipeline
+against a real project — 3061 nodes and 10887 edges of nexus analyzing itself.
+CI builds with `-W`, asserts the self-graph is non-trivial, and gates on
+`dead-references --exit-code`.
+
+Writing it surfaced a limit worth recording: nexus catches references whose
+*target* vanished, but not references the *parser* never recognised. RST role
+syntax in a MyST file renders as literal text and never becomes a reference at
+all, so there is nothing for `dead_references` to find. Both look like plain
+text to a reader; only one is detectable.
 
 ### Added — the math has structure now (#19, #21)
 

--- a/sphinxcontrib/nexus/__init__.py
+++ b/sphinxcontrib/nexus/__init__.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
 
-__version__ = "0.16.1"
+__version__ = "0.17.0"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Version bump and changelog finalisation for **0.17.0**. No behavioural change beyond what the referenced PRs already merged.

## The cycle in one line

ORPHEUS's `dead_references` went from **14 findings to 1** — and all 14 were false. The survivor is real: a docstring naming `tests.sn.test_scattering_operator` after the module moved under `operators/`, which fuzzy matching had been folding onto the live module and hiding.

## What landed

**Resolution** — #36, #37, #45, #46, #49, #50. One shared ranking replacing three separate tables; namespace-aware relative references; reconciliation deciding once over the whole graph; test helpers no longer absorbing production references; `:numref:` binding to equations, figures and tables; and `implements` no longer inferred onto tests.

**Extraction** — #38, #40. Attributes bound after the class body, and `#:` comment prose read from the token stream.

**Structure** — #19, #21. Statement relations and `sphinx-proof` typed nodes.

**Diagnostics** — #39. `minted_by` names the code that created a placeholder.

**Docs** — #52. A Sphinx guide the extension builds itself, gated in CI.

## Pre-flight

- 681 tests pass, pyright clean
- strict (`-W`) docs build clean; self-graph gate passes
- wheel builds as `0.17.0` — flit picks up the bump from `__version__`
- all 13 skill files present in the wheel, `docs/` correctly excluded

Tag `v0.17.0` after merge; CI publishes to PyPI on tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)